### PR TITLE
Fail build if command in ci-run script fails

### DIFF
--- a/bin/ci-run
+++ b/bin/ci-run
@@ -1,4 +1,6 @@
 #!/bin/bash
+set -e
+
 bundle exec bundle-audit --update
 bundle exec brakeman --run-all-checks --exit-on-warn .
 bundle exec rake


### PR DESCRIPTION
Adds a missing set -e flag to the ci-run bash script. Without this, only the last command failing would fail the build. This hasn't caused any major problems yet, but has caused a couple of feature branches to pass when they should have failed.