### PR TITLE
CVE-2019-16892: Update rubyzip

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -247,7 +247,7 @@ GEM
       rubocop (>= 0.72.0)
     ruby-progressbar (1.10.1)
     ruby_dep (1.5.0)
-    rubyzip (1.2.3)
+    rubyzip (1.3.0)
     sassc (2.1.0)
       ffi (~> 1.9)
     sassc-rails (2.1.2)


### PR DESCRIPTION
Updates Rubyzip to resolve CVE-2019-16892. This will fix [the build on master](https://app.codeship.com/projects/361577/builds/44024934?pipeline=d4d27320-7037-4100-98de-ba5f5941e7bd). 