### PR TITLE
Configure mail delivery for deployed environments

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -74,10 +74,19 @@ Rails.application.configure do
   config.action_mailer.delivery_method = :smtp
   config.action_mailer.raise_delivery_errors = true
   config.action_mailer.default_url_options = {
-    host: "glossary.nzsl.nz",
+    host: ENV["HOSTNAME"],
     protocol: "https"
   }
-  config.action_mailer.asset_host = "https://glossary.nzsl.nz"
+  config.action_mailer.smtp_settings = {
+    address: Rails.application.secrets.smtp_hostname,
+    port: 587,
+    enable_starttls_auto: true,
+    user_name: Rails.application.secrets.smtp_user_name,
+    password: Rails.application.secrets.smtp_password,
+    authentication: "login",
+    domain: ENV["HOSTNAME"]
+  }
+  config.action_mailer.asset_host = "https://#{ENV["HOSTNAME"]}"
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -24,5 +24,6 @@ test:
 # and move the `production:` environment over there.
 production:
   <<: *default
-
-
+  smtp_hostname: <%= ENV['SMTP_HOSTNAME'] %>
+  smtp_user_name: <%= ENV['SMTP_USER_NAME'] %>
+  smtp_password: <%= ENV['SMTP_PASSWORD'] %>


### PR DESCRIPTION
A little omission from the UAT environment set up - a lack of mail provider.
I have followed the Ackama standard of Mandrill to provide UAT mail delivery and configured the below credentials in Heroku.