### PR TITLE
Hide search icon when search bar gains focus to prevent browser UI from conflicting with icon

### DIFF
--- a/app/frontend/components/_search-bar.scss
+++ b/app/frontend/components/_search-bar.scss
@@ -30,6 +30,7 @@
 
     &:focus {
       background-color: $white;
+      background-image: none;
       border: 0;
       box-shadow: none;
     }


### PR DESCRIPTION
A nice simple fix. 

![image](https://user-images.githubusercontent.com/292020/66174547-11e07280-e6b2-11e9-8722-57743361700b.png)
