### PR TITLE
Add trait for sign factory

### DIFF
--- a/spec/factories/sign.rb
+++ b/spec/factories/sign.rb
@@ -9,5 +9,11 @@ FactoryBot.define do
     trait :published do
       published_at { DateTime.now - (rand * 1000) }
     end
+
+    trait :with_contributor do
+      after :build do |sign|
+        sign.contributor = FactoryBot.create(:user)
+      end
+    end
   end
 end

--- a/spec/factories/topics.rb
+++ b/spec/factories/topics.rb
@@ -7,7 +7,7 @@ FactoryBot.define do
 
     trait :with_associated_signs do
       after :build do |topic|
-        topic.signs = build_list(:sign, 5)
+        topic.signs = build_list(:sign, 5, :with_contributor)
       end
     end
   end


### PR DESCRIPTION
Hi Reviewers

Postgres will occasionally throw a 'pg not null violation' error on the contributor_id, this happens when running  specs and building sign lists. To fix create the user first then assign to the sign

Cheers
Trev H