### PR TITLE
Move @babel and @svgr packages required for a production build to complete to the main dependencies group

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,10 +2,12 @@
   "name": "nzsl_share",
   "private": true,
   "dependencies": {
+    "@babel/plugin-transform-react-jsx": "^7.3.0",
     "@rails/actioncable": "^6.0.0-alpha",
     "@rails/activestorage": "^6.0.0-alpha",
     "@rails/ujs": "^6.0.0-alpha",
     "@rails/webpacker": "^4.0.7",
+    "@svgr/webpack": "^4.3.3",
     "font-awesome": "^4.7.0",
     "foundation-sites": "^6.5.3",
     "jquery": "^3.4.1",
@@ -20,8 +22,6 @@
   ],
   "version": "0.1.0",
   "devDependencies": {
-    "@babel/plugin-transform-react-jsx": "^7.3.0",
-    "@svgr/webpack": "^4.3.3",
     "eslint": "^6.5.1",
     "eslint-config-standard": "^14.1.0",
     "eslint-plugin-import": "^2.18.2",


### PR DESCRIPTION
Heroku precompiles assets with `NODE_ENV` set to `production`, which causes Yarn to not install dev dependencies. This means that any dependencies we require for our webpacks to build need to be in the main dependencies group.

This PR resolves the failing build of origin/master @  483eab3: https://app.codeship.com/projects/361577/builds/44295394?pipeline=03fb387e-cc5d-40a6-a38d-19b6f7c3aa71