### PR TITLE
Updates required: NCG-34 and 36 - Read folder sign counts in view

### DIFF
--- a/app/views/folders/index.html.erb
+++ b/app/views/folders/index.html.erb
@@ -26,7 +26,7 @@
             created <%= folder.created_at.strftime("%d %b %Y") %>
           </div>
           <div class="cell small-3 folder__details">
-            <%= folder.signs_count %> <%= folder.signs_count === 1 ? "sign" : "signs" %>
+            <%= pluralize(folder.signs_count, "sign") %>
             <a href="#" class="folder__icon--options" data-toggle="<%= dom_id(folder, :options) %>" title="Folder Options">
               <%= inline_svg "media/images/options.svg", class: "icon--medium folder__icon" %>
             </a>


### PR DESCRIPTION
This PR updates the folders index view to display the correct sign count for each folder. Previously this was hardcoded with `0 signs` as a placeholder. 

![Screen Shot 2019-10-18 at 3 51 37 PM](https://user-images.githubusercontent.com/10970711/67062232-33b41c00-f1bf-11e9-8fc0-79632fc8117e.png)

