### PR TITLE
Bugfix/ NCG-230: Get rid of extra margin in hero search bar

### DIFF
--- a/app/frontend/components/_hero-unit.scss
+++ b/app/frontend/components/_hero-unit.scss
@@ -25,12 +25,16 @@
   }
 
   &__search {
+    > .search-bar > label {
+      margin: 0;
+    }
+
     > .search-bar > label > input {
       background: $white;
       background-image: url("images/search.svg");
       background-position: calc(100% - 1rem);
       background-repeat: no-repeat;
-      margin: 0;
+      margin: 0 !important; // sass-lint:disable-line no-important
       padding-right: 2rem;
       transition: box-shadow, background-color linear 0.5s;
     }


### PR DESCRIPTION
Fixes NCG-230. The search bar and the browse topics dropdown were misaligned in the hero banner due to the margin settings on the search. 