### PR TITLE
Wait a bit longer

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -37,7 +37,7 @@ rescue ActiveRecord::PendingMigrationError => e
   exit 1
 end
 
-Capybara.default_wait_time = 5.seconds # Default is 2 seconds
+Capybara.default_max_wait_time = 5.seconds # Default is 2 seconds
 Capybara.register_driver :chrome do |app|
   options = Selenium::WebDriver::Chrome::Options.new
 


### PR DESCRIPTION
We've been having some system tests failing to find elements in time. Since the default is 2 seconds, and some of our AJAX interactions could conceivably take longer than that (file uploads), let's allow Capybara a bit more time to find what it's looking for.