### PR TITLE
Switch to async adapter when running tests

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -52,4 +52,6 @@ Rails.application.configure do
 
   # Run queued tasks in an async queue
   Rails.application.config.active_job.queue_adapter = :async
+  require "sidekiq/testing"
+  Sidekiq::Testing.inline!
 end


### PR DESCRIPTION
The default test adapter for ActiveJob _was_ `inline`. This runs jobs...inline, which was causing some super chaotic behaviour when it came time to encode videos.

This PR switches the default adapter to `async`, which will still process the jobs, but does not require a separate process to run (e.g. Sidekiq) for the tests, and also runs independently of the request, which should cut down on the test failures we have due to timeouts.