### PR TITLE
Add new state 'archived', that archived copies of signs are transitioned to

### DIFF
--- a/app/models/sign.rb
+++ b/app/models/sign.rb
@@ -18,7 +18,7 @@ class Sign < ApplicationRecord
   validates :word, presence: true
   validates :conditions_accepted,
             presence: true,
-            unless: -> { personal? }
+            unless: -> { personal? || archived? }
 
   # See app/validators/README.md for details on these
   # validations
@@ -55,6 +55,7 @@ class Sign < ApplicationRecord
     state :published, before_enter: -> { self.published_at = Time.zone.now }
     state :declined, before_enter: -> { self.declined_at = Time.zone.now }
     state :unpublish_requested, before_enter: -> { self.requested_unpublish_at = Time.zone.now }
+    state :archived
 
     event :make_private do
       transitions from: %i[submitted declined], to: :personal

--- a/app/services/archive_sign.rb
+++ b/app/services/archive_sign.rb
@@ -8,6 +8,7 @@ class ArchiveSign < ApplicationService
     @sign
       .then(&:dup) # After this point we're acting on the copy
       .then(&method(:reassign_contributor))
+      .then(&method(:assign_state))
       .tap(&:save!)
       .then(&method(:copy_attachments))
   end
@@ -16,6 +17,11 @@ class ArchiveSign < ApplicationService
 
   def reassign_contributor(sign)
     sign.contributor = @user
+    sign
+  end
+
+  def assign_state(sign)
+    sign.status = :archived
     sign
   end
 

--- a/spec/services/archive_sign_spec.rb
+++ b/spec/services/archive_sign_spec.rb
@@ -19,6 +19,10 @@ RSpec.describe ArchiveSign, type: :service do
       expect(clone.contributor).to eq user
     end
 
+    it "changes the status of the sign copy to 'archived'" do
+      expect(subject).to be_archived
+    end
+
     it "creates a new attachment for the sign video" do
       clone = nil
       expect { clone = subject }.to change(ActiveStorage::Attachment, :count).by(1)


### PR DESCRIPTION
During my UAT testing of unpublishing, I realised that I'd missed the addition of a new archived state that unpublished signs are transitioned to. Without this state, the archived copy of the sign is actually saved as a published record, which isn't right. 

Because this introduces a new state, the admin panel automatically gains a filter option for "Archived" signs.