### PR TITLE
Add data-closable to flash messages so they are actually closable

### DIFF
--- a/app/views/application/_messages.html.erb
+++ b/app/views/application/_messages.html.erb
@@ -4,7 +4,7 @@
     <div class="cell auto">
       <%# Notice %>
       <% if flash[:notice].present? %>
-        <div class="callout success grid-x grid-margin-x">
+        <div class="callout success grid-x grid-margin-x" data-closable>
           <div class="cell shrink align-self-middle">
             <%= inline_svg "media/images/remove.svg", class: "icon icon--white icon--mid" %>
           </div>
@@ -22,7 +22,7 @@
 
       <%# Alert %>
       <% if flash[:alert].present? %>
-        <div class="callout alert grid-x grid-margin-x">
+        <div class="callout alert grid-x grid-margin-x" data-closable>
           <div class="cell shrink align-self-middle">
             <%= inline_svg "media/images/remove.svg", class: "icon icon--white icon--mid" %>
           </div>


### PR DESCRIPTION
![Peek 2019-11-21 10-58](https://user-images.githubusercontent.com/292020/69281853-e90a4180-0c4d-11ea-83fd-9bc003c1a3c3.gif)

Since we have a close button, we should actually make those alerts closable 