### PR TITLE
NCG-247: Do not store user location when serving sign videos. This prevents a user being redirected to a video after sign-in

### DIFF
--- a/app/controllers/videos_controller.rb
+++ b/app/controllers/videos_controller.rb
@@ -1,4 +1,6 @@
 class VideosController < ApplicationController
+  skip_before_action :store_user_location!
+
   PRESET_MAP = {
     "1080p" => VideoEncodingPreset.default.muted.scale_1080,
     "720p" => VideoEncodingPreset.default.muted.scale_720,
@@ -13,6 +15,8 @@ class VideosController < ApplicationController
 
     redirect_to representation.processed
   end
+
+  private
 
   def blob
     ActiveStorage::Blob.find_signed(params[:id])


### PR DESCRIPTION
Thanks to @l-suzuki for reporting this in Jira and for getting me :duck: ing my way to a nice clean solution.