### PR TITLE
Install and configure Raygun for exception tracking

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,6 +24,7 @@ gem "sidekiq-batch"
 gem "image_processing"
 gem "aasm"
 gem "administrate"
+gem "raygun4ruby"
 
 gem "rack-canonical-host"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -152,6 +152,9 @@ GEM
     ffi (1.11.1)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
+    httparty (0.17.1)
+      mime-types (~> 3.0)
+      multi_xml (>= 0.5.2)
     i18n (1.7.0)
       concurrent-ruby (~> 1.0)
     ice_nine (0.11.2)
@@ -198,6 +201,9 @@ GEM
     marcel (0.3.3)
       mimemagic (~> 0.3.2)
     method_source (0.9.2)
+    mime-types (3.3)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2019.1009)
     mimemagic (0.3.3)
     mini_magick (4.9.5)
     mini_mime (1.0.2)
@@ -207,6 +213,7 @@ GEM
     momentjs-rails (2.20.1)
       railties (>= 3.1)
     msgpack (1.3.1)
+    multi_xml (0.6.0)
     multipart-post (2.1.1)
     nio4r (2.4.0)
     nokogiri (1.10.5)
@@ -267,6 +274,11 @@ GEM
       thor (>= 0.20.3, < 2.0)
     rainbow (3.0.0)
     rake (12.3.3)
+    raygun4ruby (3.2.1)
+      concurrent-ruby
+      httparty (> 0.13.7)
+      json
+      rack
     rb-fsevent (0.10.3)
     rb-inotify (0.10.0)
       ffi (~> 1.0)
@@ -403,6 +415,7 @@ DEPENDENCIES
   pundit
   rack-canonical-host
   rails (= 6.0.0)
+  raygun4ruby
   redis
   rspec-rails
   rubocop

--- a/config/initializers/raygun.rb
+++ b/config/initializers/raygun.rb
@@ -1,0 +1,9 @@
+if ENV["RAYGUN_API_KEY"]
+  Raygun.setup do |config|
+    config.api_key = ENV["RAYGUN_API_KEY"]
+    config.filter_parameters = Rails.application.config.filter_parameters
+
+    # The default is Rails.env.production?
+    # config.enable_reporting = !Rails.env.development? && !Rails.env.test?
+  end
+end


### PR DESCRIPTION
Adds a new gem to the Gemfile and configures an initialiser to enable Raygun if an API key is present (and the app is running in RAILS_ENV=production).

Raygun is the most appropriate platform to start off with for this application, since our customer & code care team is most familiar with this tool. Transitioning to Sentry is on their roadmap and this project should track that, given that Sentry has a good OSS free plan we could take advantage of once the project has been open-sourced. (https://sentry.io/for/open-source/)