### PR TITLE
Always show 'Learn more' link on homepage. If the user is not signed in, they will be redirect back to the form

### DIFF
--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -26,7 +26,7 @@
     </div>
     <h6>Discuss signs</h6>
     <p>Approved members comment on signs, agree or disagree</p>
-    <%= link_to "Learn more", new_approved_user_application_path %>
+    <%= link_to "Learn more", edit_user_registration_path(anchor: "approved-member-information") %>
   </div>
 
   <div class="home-main__container cell small-6 medium-3">

--- a/app/views/users/registrations/edit.html.erb
+++ b/app/views/users/registrations/edit.html.erb
@@ -11,7 +11,7 @@
 
       <div>
         <%= f.label :email %>
-        <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+        <%= f.email_field :email, autocomplete: "email" %>
       </div>
 
       <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
@@ -29,7 +29,7 @@
       </div>
     </fieldset>
 
-    <div class="form__section">
+    <div class="form__section" id="approved-member-information">
       <h2 class="primary">Approved Member</h2>
       <hr class="form__divider margin-bottom-2">
 


### PR DESCRIPTION
No idea what I was thinking. I think we always want to show this link? If the user isn't signed in, they will be redirect back to the form after signing in/up. 

![image](https://user-images.githubusercontent.com/292020/69687657-a3a3b380-1128-11ea-9456-3f280d65fdf2.png)


I guess the only question is what happens with users who are already approved users - if they click on this link they'll get the unauthorized error message, which isn't great. Maybe this could go to the user registration edit page, with an anchor pointing specifically to the approved users section?