### PR TITLE
Add Google Analytics tracking

### DIFF
--- a/app/views/application/analytics/google/_body.html.erb
+++ b/app/views/application/analytics/google/_body.html.erb
@@ -1,0 +1,6 @@
+<% if container_id = Rails.application.config.google_analytics_container_id %>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=<%= escape_javascript(container_id) %>"
+                    height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+<% end %>

--- a/app/views/application/analytics/google/_head.html.erb
+++ b/app/views/application/analytics/google/_head.html.erb
@@ -1,0 +1,9 @@
+<% if container_id = Rails.application.config.google_analytics_container_id %>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+      j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+      'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','<%= escape_javascript(container_id) %>');</script>
+  <!-- End Google Tag Manager -->
+<% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -3,6 +3,8 @@
   <head>
     <title><%= strip_tags(yield(:title)) + " – " if content_for?(:title) -%>NZSL Share</title>
 
+    <%= render "application/analytics/google/head" %>
+
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
 
@@ -43,6 +45,7 @@
   <body class="no-js">
     <%# Prevent FOUS on page load %>
     <script>document.body.classList.remove("no-js");</script>
+    <%= render "application/analytics/google/body" %>
 
     <%= render "application/header" %>
     <% # Authenticated layout renders these %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -29,5 +29,6 @@ module NzslShare
     config.active_model.i18n_customize_full_message = true
 
     config.contact_email = ENV.fetch("CONTACT_EMAIL", ENV["MAIL_FROM"])
+    config.google_analytics_container_id = ENV["GOOGLE_ANALYTICS_CONTAINER_ID"]
   end
 end


### PR DESCRIPTION
Render GA script and noscript tags, if a GOOGLE_ANALYTICS_CONTAINER_ID is specified in config.
Tested locally, and container ID has been configured for production.