### PR TITLE
System user must have a valid username to be routable

### DIFF
--- a/app/models/system_user.rb
+++ b/app/models/system_user.rb
@@ -1,7 +1,7 @@
 class SystemUser
   class << self
     def find
-      User.where(username: "nzsl-share").first_or_initialize do |user|
+      User.where(username: "nzsl.share").first_or_initialize do |user|
         # We do not want the system user to be log-in-able.
         # This means no email or password.
         user.save(validate: false)


### PR DESCRIPTION
Our User username regexp allows '.' but not '-'. This makes links to the system user break, since the routing constraint is not met.