### PR TITLE
NCG-254: Shorten placeholder in approved user applications search bar

### DIFF
--- a/app/views/admin/approved_user_applications/index.html.erb
+++ b/app/views/admin/approved_user_applications/index.html.erb
@@ -63,7 +63,7 @@ It renders the `_table` partial to display details about the resources.
       <%= render(
         "search",
         search_term: search_term,
-        resource_name: display_resource_name(page.resource_name)
+        resource_name: "Applications"
       ) %>
       </div>
     <% end %>


### PR DESCRIPTION
Tiny pr to simplify the placeholder name in the approved user applications search bar: 
<img width="232" alt="Screen Shot 2019-12-02 at 10 13 31 AM" src="https://user-images.githubusercontent.com/10970711/69920421-a4ec2c00-14ec-11ea-95d5-c7dbe3695c0b.png">
