### PR TITLE
Change test to use a sign with pre-processed thumbnails and videos ra…

### DIFF
--- a/spec/system/edit_sign_feature_spec.rb
+++ b/spec/system/edit_sign_feature_spec.rb
@@ -152,8 +152,11 @@ RSpec.describe "Editing a sign", type: :system do
     end
 
     context "when the sign video has been encoded" do
-      before { sign.update!(processed_thumbnails: true, processed_videos: true); }
-      it { expect(subject).to have_selector("source[src*='/videos']", wait: 30, count: 3, visible: false) }
+      let(:sign) { FactoryBot.create(:sign, :processed_thumbnails, :processed_videos, contributor: user) }
+
+      it {
+        expect(subject).to have_selector("source[src*='/videos']", count: 3, visible: false)
+      }
     end
   end
 


### PR DESCRIPTION
## Change test to use a sign with pre-processed thumbnails and videos rather than doing this during test, because the Ajax response is flaky in CI.

The old test visited the sign edit page, updated the sign to have processed thumbnails and  videos, and then watched the page to see if this updated the video src. This has been causing frequent failures on CI for reasons that are not 100% clear but presumably are related to constrained CPU resources not fulfilling the Ajax call. The wait was recently updated to 30 seconds to try mitigate this, but this strategy has had limited success.

The new test visits the sign page when the sign has processed thumbnails and videos and checks that the src or this renders. This means that the Ajax call is not made which sidesteps the challenge faced by the previous version. The obvious downside to this is that the Ajax call is not being tested any more but as this is an "enhancement" as opposed to core functionality, in discussion with @lamorrison I have concluded that by ensuring that the src does render on the page, the test fulfills the original description of "when the sign video has been encoded", meaning the test can now be consistently expected to pass and if it fails it will be a reliable signal to future devs that something is indeed broken.

It is also worth noting that I have never observed the Ajax call to fail on my local dev environment or on UAT,  which leads me to believe to that this is only an issue in the CI environment, presumably due to resource constraints.