### PR TITLE
NCG-258: Make hero unit full width

### DIFF
--- a/app/views/layouts/authenticated_home.html.erb
+++ b/app/views/layouts/authenticated_home.html.erb
@@ -16,11 +16,17 @@
     <div class="cell shrink sidebar sidebar--inside-grid">
       <%= render "application/sidebar/signed_in" %>
     </div>
-    <div class="grid-container cell auto">
+
+    <div class="grid-x cell auto">
+      <div class="cell">
       <%= render("application/messages",
-               classes: request.path == root_path ? "messages--float" : "") %>
+                classes: request.path == root_path ? "messages--float" : "") %>
+
       <%= render "application/hero-unit" %>
-      <%= yield %>
+      </div>
+      <div class="grid-container">
+        <%= yield %>
+      </div>
     </div>
   </div>
 <% end %>


### PR DESCRIPTION
Fixes UI bug where the hero unit wasn't taking up the full width that it should. 

Before:
<img width="1187" alt="Screen Shot 2019-12-02 at 12 00 38 PM" src="https://user-images.githubusercontent.com/10970711/69927101-d03a3f80-151b-11ea-9b5d-382258de08db.png">

After: 
<img width="1186" alt="Screen Shot 2019-12-02 at 12 02 27 PM" src="https://user-images.githubusercontent.com/10970711/69927090-c7e20480-151b-11ea-99ab-d2f1670df321.png">
