### PR TITLE
NCG-257: Use font-weight 500 for normal 

### DIFF
--- a/app/frontend/foundation/overrides/typography.scss
+++ b/app/frontend/foundation/overrides/typography.scss
@@ -1,5 +1,5 @@
 // sass-lint:disable no-url-domains, no-url-protocols
-@import url("//fonts.googleapis.com/css?family=Montserrat:400,400i,500,500i,700,700i&display=swap");
+@import url("//fonts.googleapis.com/css?family=Montserrat:500,500i,700,700i&display=swap");
 // sass-lint:enable no-url-domains, no-url-protocols
 
 h1,


### PR DESCRIPTION
Only import font-weight 500 (normal) and 700 (bold).
Do not import font-weight 400 as it renders strangely on low res screens. 

