### PR TITLE
Replace 'popular' sort for freelex search

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -18,7 +18,7 @@ class SearchController < ApplicationController
   end
 
   def freelex_search_results
-    @freelex_search_results ||= FreelexSearchService.call(search: clone_search, relation: freelex_search_relation)
+    @freelex_search_results ||= FreelexSearchService.call(search: freelex_search, relation: freelex_search_relation)
   end
 
   def search_relation
@@ -33,7 +33,7 @@ class SearchController < ApplicationController
     { term: params.require(:term) }.merge(params.permit(:page, :sort))
   end
 
-  def clone_search
+  def freelex_search
     return search unless search.sort.to_s.downcase == "popular"
 
     clone = search.clone


### PR DESCRIPTION
Hi Reviewers

This is to fix a search bug. A 'popular' sort is not compatible with a freelex search. We don't have the data to determine whats popular for a freelex search (yet) so until we do replace the popular sort option for a freelex search with  'alpha_asc'

Cheers
T :smile: 

