### PR TITLE
Respond to JS request with inline script to open an alert with the same message shown for HTML requests

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -38,8 +38,10 @@ class ApplicationController < ActionController::Base
   private
 
   def user_not_authorized
-    redirect_back fallback_location: root_path,
-                  alert: t("application.unauthorized")
+    respond_to do |format|
+      format.html { redirect_back fallback_location: root_path, alert: t("application.unauthorized") }
+      format.js { render inline: "alert(\"#{t("application.unauthorized")}\");" }
+    end
   end
 
   def http_basic_auth


### PR DESCRIPTION
This PR resolves an issue where unauthorized XHR requests silently fail when used with `data-remote=true` on forms or links. 

When Pundit raises an unauthorized error, we now respond with an inline JS to open an alert with an identical message to that used in the flash message we show for non-XHR requests.