### PR TITLE
Adjustments to associations which are eager loaded to avoid some N+1 queries

### DIFF
--- a/app/controllers/signs_controller.rb
+++ b/app/controllers/signs_controller.rb
@@ -2,7 +2,7 @@ class SignsController < ApplicationController
   before_action :authenticate_user!, except: %i[show]
 
   def show
-    @sign = present(signs.includes(:contributor, :topics, :sign_comments).find(id))
+    @sign = present(signs.includes(:contributor, :topics, :folders, sign_comments: :replies).find(id))
     authorize @sign
 
     @sign.topic = fetch_referer
@@ -71,7 +71,7 @@ class SignsController < ApplicationController
 
   def sign_comments
     @comments = policy_scope(@sign.sign_comments)
-                .includes(user: :avatar_attachment).where(folder_id: comments_folder_id)
+                .includes(:replies, user: :avatar_attachment).where(folder_id: comments_folder_id)
                 .page(params[:comments_page]).per(10)
   end
 


### PR DESCRIPTION
I noticed that the sign show page was loading very slowly because of comments loading their replies one at a time instead of in a batched join. 

This PR adds a couple of eager load statements so the sign should load in advance the folders and sign comment replies so these don't need to issue individual select statements.