### PR TITLE
Update JS components for sign commenting to init their elements on page load

### DIFF
--- a/app/frontend/components/character-count.js
+++ b/app/frontend/components/character-count.js
@@ -1,5 +1,6 @@
 $(document).ready(() => {
-  $("body").on("keyup", ":input", ({ target }) =>
-    $(`[data-character-count='${target.id}'`).text(target.value.length)
-  );
+  const updateCount = ({ target }) =>  target.value && $(`[data-character-count='${target.id}'`).text(target.value.length);
+
+  $("body").on("keyup", ":input", updateCount);
+  $(":input").each((_idx, el) => updateCount({ target: el }));
 });

--- a/app/frontend/components/sign-comments.js
+++ b/app/frontend/components/sign-comments.js
@@ -28,6 +28,8 @@ $(document).ready(function() {
     }
   });
 
+  $(".js-sign-comment-type-new").trigger("change");
+
   $("body").on("change", ".js-sign-comment-type-reply", function(event) {
     event.preventDefault();
     var option = $(this).val();


### PR DESCRIPTION
This ensures that the components are in the correct state when the page loads without requiring user interaction. In particular, this PR addresses character counts that were not correct, and the selected value of sign comment types.