### PR TITLE
NCG-92-Fixes: Increase text area rows and open links in new tab 

### DIFF
--- a/app/controllers/sign_comments_controller.rb
+++ b/app/controllers/sign_comments_controller.rb
@@ -4,7 +4,8 @@ class SignCommentsController < ApplicationController
   def create
     @sign = fetch_sign
     @sign_comment = SignComment.new(build_text_comment)
-    authorize @sign_comment
+    authorize_create!(@sign_comment)
+
     @sign_comment.save
     @sign.reload
     refresh_comments
@@ -50,6 +51,17 @@ class SignCommentsController < ApplicationController
                        end
       end
     end
+  end
+
+  def authorize_create!(sign_comment)
+    policy = SignCommentPolicy.new(
+      current_user,
+      sign_comment,
+      current_folder_id: sign_comment.folder_id)
+
+    return true if policy.create?
+
+    fail NotAuthorizedError, query: :create, record: sign_comment, policy: policy
   end
 
   def comment_params

--- a/app/controllers/signs_controller.rb
+++ b/app/controllers/signs_controller.rb
@@ -3,6 +3,8 @@ class SignsController < ApplicationController
 
   def show
     @sign = present(signs.includes(:contributor, :topics, :folders, sign_comments: :replies).find(id))
+    @current_folder_id = params[:comments_in_folder]
+    @new_comment = SignComment.new(sign: @sign.sign)
     authorize @sign
     @sign.topic = fetch_referer
     sign_comments
@@ -24,10 +26,9 @@ class SignsController < ApplicationController
   end
 
   def create
-    builder = build_sign
-    @sign = builder.sign
+    @sign = build_sign.sign
     authorize @sign
-    return render(:new) unless builder.save
+    return render(:new) unless build_sign.save
 
     flash[:notice] = t(".success")
     respond_to do |format|
@@ -84,7 +85,7 @@ class SignsController < ApplicationController
   end
 
   def build_sign(builder: SignBuilder.new)
-    builder.build(create_sign_params)
+    @build_sign ||= builder.build(create_sign_params)
   end
 
   def create_sign_params

--- a/app/policies/sign_policy.rb
+++ b/app/policies/sign_policy.rb
@@ -1,4 +1,10 @@
 class SignPolicy < ApplicationPolicy
+  def initialize(user, record, current_folder_id: nil)
+    @user = user
+    @record = record
+    @current_folder_id = current_folder_id
+  end
+
   def index?
     true
   end
@@ -35,14 +41,6 @@ class SignPolicy < ApplicationPolicy
     return true if public_record?
 
     Pundit.policy_scope(user, record.folders).any?
-  end
-
-  def allow_new_comment?
-    owns_record? || user&.approved? || user&.administrator?
-  end
-
-  def allow_comment_options?
-    allow_new_comment?
   end
 
   def destroy?
@@ -148,6 +146,6 @@ class SignPolicy < ApplicationPolicy
 
     record.folders.left_outer_joins(:collaborations)
           .where(folders: { collaborations: { collaborator_id: user.id } })
-          .any?
+          .exists?
   end
 end

--- a/app/views/sign_comments/_comments.html.erb
+++ b/app/views/sign_comments/_comments.html.erb
@@ -39,7 +39,7 @@
 
   <hr class="sign-comments__divider">
 
-  <%= render "sign_comments/new", sign: @sign if policy(@sign).allow_new_comment? %>
+  <%= render "sign_comments/new", sign: @sign if SignCommentPolicy.new(current_user, @new_comment, current_folder_id: @current_folder_id).create? %>
 
   <div class="margin-bottom-1"></div>
 </div>

--- a/app/views/sign_comments/_comments_list.html.erb
+++ b/app/views/sign_comments/_comments_list.html.erb
@@ -13,7 +13,8 @@
 
     <div class="grid-x align-middle grid-padding-x sign-comments__replies">
       <div class="cell auto sign-comments__replies--reply">
-        <% if policy(@sign).allow_new_comment? %>
+
+        <% if SignCommentPolicy.new(current_user, comment, current_folder_id: @current_folder_id).create? %>
           <span class="cell auto">
             <%= content_tag "a", nil, data: { id: dom_id(comment) }, class: "js-sign-comment-reply sign-comments__replies--reply sign-comments__replies--link" do %>
               <%= inline_svg "media/images/reply.svg", aria_hidden: true, class: "icon icon--medium" %>
@@ -29,7 +30,7 @@
       </div>
     </div>
 
-    <% if policy(@sign).allow_new_comment? %>
+    <% if SignCommentPolicy.new(current_user, comment, current_folder_id: @current_folder_id).create? %>
       <div id="<%= dom_id(comment) %>" class="sign-comments__replies" style="display:none">
         <%= render "sign_comments/reply", comment: comment %>
       </div>

--- a/app/views/sign_comments/_new.html.erb
+++ b/app/views/sign_comments/_new.html.erb
@@ -1,6 +1,6 @@
 <%= render "sign_comments/shared/selects", js_sign_comment: "js-sign-comment-type-new" %>
 <div id="new-text-comment">
-  <%= form_with model: SignComment.new, url: sign_comments_path(@sign) do |f| %>
+  <%= form_with model: @new_comment, url: sign_comments_path(@sign) do |f| %>
     <%= render "sign_comments/shared/text", comment: f.object, parent: nil, f: f %>
   <% end %>
 </div>

--- a/app/views/sign_comments/shared/_options.html.erb
+++ b/app/views/sign_comments/shared/_options.html.erb
@@ -1,4 +1,3 @@
-<% if policy(comment.sign).allow_comment_options? %>
 <a href="#" data-toggle="<%= dom_id(comment, :options) %>" title="Comment Options">
   <%= inline_svg "media/images/options.svg", class: "icon--medium list__item__icon" %>
 </a>
@@ -30,4 +29,3 @@
     <% end %>
   </ul>
 </div>
-<% end %>

--- a/spec/requests/sign_comment_spec.rb
+++ b/spec/requests/sign_comment_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.describe "sign_comment", type: :request do
-  let(:user) { FactoryBot.create(:user) }
+  let(:user) { FactoryBot.create(:user, :approved) }
   let(:sign) { FactoryBot.create(:sign, :published) }
 
   let(:create_params) { { comment: "my first comment" } }
@@ -77,16 +77,6 @@ RSpec.describe "sign_comment", type: :request do
         expect(sign.sign_comments.count).to eq 0
         expect(response).to redirect_to sign_path(sign)
       end
-
-      it "will delete a comment for the sign owner" do
-        sign.update(contributor: user)
-        expect(sign.sign_comments.count).to eq 0
-        create.call(sign)
-        expect(sign.sign_comments.count).to eq 1
-        destroy.call(sign, sign.sign_comments.first)
-        expect(sign.sign_comments.count).to eq 0
-        expect(response).to redirect_to sign_path(sign)
-      end
     end
 
     describe "update" do
@@ -101,8 +91,7 @@ RSpec.describe "sign_comment", type: :request do
         expect(response).to redirect_to sign_path(sign)
       end
 
-      it "will update a comment for the sign owner" do
-        sign.update(contributor: user)
+      it "will update a comment for the commenter" do
         expect(sign.sign_comments.count).to eq 0
         create.call(sign)
         expect(sign.sign_comments.count).to eq 1


### PR DESCRIPTION
Hi Reviewers

Some fixes for NCG-92 increase text and video comment text area and links should open in a new tab.

In order to open links in comments in new tabs I needed to set the target attribute, however rails would strip this before rendering which forced me to set the _sanitise_ option on _simple_format_ to _false_. As a result any comments that were saved with tags would also be rendered with tags in tact ... my approach to this was to sanitise the input before save to prevent any surprises when  comments were rendered

Cheers
T