### PR TITLE
Disable sign show page caching until records correctly touch the parent sign to clear the cache

### DIFF
--- a/app/controllers/signs_controller.rb
+++ b/app/controllers/signs_controller.rb
@@ -8,7 +8,6 @@ class SignsController < ApplicationController
     authorize @sign
     @sign.topic = fetch_referer
     sign_comments
-    return unless stale?(@sign)
 
     render
   end


### PR DESCRIPTION
Issues on environments with caching enabled have arisen because we have not maintained our relationships with a sign to ensure that the parent record is updated when an association is changed (e.g. comments), which would bust HTTP caching. 

Additionally, we should not cache pages for signed in users, since this can result in apparent user switching.

I have opted to disbable this caching entirely for now, since the correction will require changes to some associations and the stale logic.