### PR TITLE
NCG-274: Set size class on the video tag not the wrapper

### DIFF
--- a/app/views/sign_comments/shared/_comment.html.erb
+++ b/app/views/sign_comments/shared/_comment.html.erb
@@ -23,8 +23,8 @@
     <span class="cell auto">
       <%= comment.video_description %><br>
     </span>
-    <span class="cell auto video-wrapper data-overlay sign-comments__video">
-      <%= video_tag url_for(comment.video), controls: true %>
+    <span class="cell auto video-wrapper data-overlay">
+      <%= video_tag url_for(comment.video), controls: true, class: "sign-comments__video" %>
     </span>
   <% else %>
     <span class="cell auto">


### PR DESCRIPTION
Hi Reviewers

Set the size class on the video tag not the wrapper as will display oddly on some browsers i.e google-chrome affected

Cheers
T 