### PR TITLE
NCG-278: Don't display parent create dates for replies

### DIFF
--- a/app/views/sign_comments/_comments_list.html.erb
+++ b/app/views/sign_comments/_comments_list.html.erb
@@ -46,7 +46,7 @@
 
       <div class="grid-x grid-padding-x sign-comments__replies">
         <div class="cell auto sign-comments__replies sign-comments__replies--reply">
-          <%= comment.friendly_date %>
+          <%= reply.friendly_date %>
         </div>
       </div>
     <% end %>


### PR DESCRIPTION
Hi Reviewers

Fix for a small bug where the parent create date is displayed for its replies

Cheers
T