### PR TITLE
NCG-279: Display notes for sign show page

### DIFF
--- a/app/frontend/components/_sign-card.scss
+++ b/app/frontend/components/_sign-card.scss
@@ -60,6 +60,16 @@
     padding: 0 1rem;
   }
 
+  &__text-area {
+    &--notes {
+      color: $medium-gray;
+      font-size: 0.875rem;
+      font-weight: normal;
+      margin-bottom: 1rem;
+      margin-top: 0.5rem;
+    }
+  }
+
   &__folders {
     &__button {
       align-items: center;

--- a/app/views/signs/show.html.erb
+++ b/app/views/signs/show.html.erb
@@ -61,9 +61,11 @@
           &nbsp;•&nbsp;
           <%= @sign.topic.name %>
         <% end %>
-    </p>
+      </p>
 
-      <%= content_tag(:p, simple_format(@sign.description)) %>
+      <div class="sign-card__text-area--notes">
+        <%= simple_format(@sign.notes) %>
+      </div>
     </div>
 
     <% if @sign.usage_examples.any? %>

--- a/spec/system/sign_show_page_spec.rb
+++ b/spec/system/sign_show_page_spec.rb
@@ -339,9 +339,9 @@ RSpec.describe "Sign show page", system: true do
     subject.breadcrumb { expect(subject).to have_link sign.topics.first.name }
   end
 
-  it "displays the sign description" do
-    sign.update!(description: "Hello, world!")
-    visit current_path # Reload
+  it "displays the sign notes" do
+    sign.update!(notes: "Hello, world!")
+    visit current_path
     expect(subject).to have_selector "p", text: "Hello, world!"
   end
 


### PR DESCRIPTION
Hi Reviewers

It looks like the description isn't being displayed or saved as part of the sign creation or update. I **_think_**  notes was favoured over description and description should be removed. Further investigation is required to see if that is the case so I'll leave the description in tacked for now :smile:

For this patch display the sign notes for the sign show page.

![Screenshot_2020-03-12 test](https://user-images.githubusercontent.com/54783624/76466259-29373f00-644c-11ea-84dc-f6bd956f3599.png)

Cheers
T