### PR TITLE
NCG-281: Format date-time for comments

### DIFF
--- a/app/presenters/sign_comment_presenter.rb
+++ b/app/presenters/sign_comment_presenter.rb
@@ -7,7 +7,7 @@ class SignCommentPresenter < ApplicationPresenter
   def friendly_date
     created = sign_comment.created_at
 
-    return h.localize(created, format: "%-d %b %I:%M %p %Y") unless created.today?
+    return h.localize(created, format: "%-d %b %Y %I:%M %p") unless created.today?
 
     "Today at #{h.localize(created, format: "%I:%M %p")}"
   end


### PR DESCRIPTION
Hi Reviewers

Quick fix to format date-time for comments and replies > 24 hours

**Example**:

_Currently_

14 Feb 1:15 pm 2020

_Should be_

14 Feb 2020 1:15 pm

Cheers
T
