### PR TITLE
NCG-282: Include private collaboration signs for moderators

### DIFF
--- a/app/policies/sign_policy.rb
+++ b/app/policies/sign_policy.rb
@@ -113,8 +113,13 @@ class SignPolicy < ApplicationPolicy
     end
 
     def resolve
-      if user && user.moderator
-        resolve_moderator
+      if user&.moderator?
+        collaboration_sign_ids =
+          user.collaborations
+              .joins(folder: :folder_memberships)
+              .pluck("folder_memberships.sign_id")
+
+        Sign.where(id: collaboration_sign_ids).or(resolve_moderator)
       elsif user
         resolve_user
       else


### PR DESCRIPTION
Hi Reviewers

A bug exists where, if the user is a moderator any private signs they are invited to collaborate on, will throw an error when they view them. This is due to the nature of the _resolve_moderator_ query that excludes private signs from the result set

So to fix ... fetch any signs of which the moderator is a collaborator of and include them in the _resolve_moderator_ result set (essentially a union of active_record relation which will also blow out dupes)

Cheers
T