### PR TITLE
NCG-284: Fix array compatibility error

### DIFF
--- a/app/policies/sign_policy.rb
+++ b/app/policies/sign_policy.rb
@@ -119,6 +119,8 @@ class SignPolicy < ApplicationPolicy
               .joins(folder: :folder_memberships)
               .pluck("folder_memberships.sign_id")
 
+        return resolve_moderator if collaboration_sign_ids.blank?
+
         Sign.where(id: collaboration_sign_ids).or(resolve_moderator)
       elsif user
         resolve_user


### PR DESCRIPTION
Hi Reviewers

An empty array is certainly not the same as an empty active record relation array, so return early if we encounter this situation.

Cheers
T