### PR TITLE
Bugfix/NCG-288: sign show page contributor avatars

### DIFF
--- a/app/views/signs/show.html.erb
+++ b/app/views/signs/show.html.erb
@@ -48,11 +48,10 @@
     <div class="grid-x sign-card__section">
       <p class="sign-card__subtitle">
         <%= link_to user_path(@sign.contributor.username) do %>
-          <img
-            class="avatar avatar--small avatar--left"
-            src="https://picsum.photos/id/550/32/32"
-            alt="Profile Image"
-          />
+          <% contributor = present(@sign.contributor) %>
+          <%= contributor.avatar("avatar avatar--small avatar--left") %>
+        <% end %>
+        <%= link_to user_path(@sign.contributor.username) do %>
           <%= @sign.contributor.username %>
         <% end %>
         &nbsp;•&nbsp;uploaded&nbsp;


### PR DESCRIPTION
Sign show page was displaying an old placeholder avatar instead of the NZSL share user's avatar. The avatar and username text were also a bit misaligned with the rest of the text on that line, so this has also been fixed.

Before:
<img width="364" alt="Screen Shot 2020-04-03 at 2 30 57 PM" src="https://user-images.githubusercontent.com/10970711/78728407-58799700-798b-11ea-952d-0eabd9417edd.png">

After:
<img width="843" alt="Screen Shot 2020-04-03 at 2 50 30 PM" src="https://user-images.githubusercontent.com/10970711/78728459-7e9f3700-798b-11ea-9040-d047d225bd0d.png">
