### PR TITLE
Return a stable URL to the ActiveStorage::Blob that represents a video thumbnai

### DIFF
--- a/app/presenters/sign_presenter.rb
+++ b/app/presenters/sign_presenter.rb
@@ -66,8 +66,9 @@ class SignPresenter < ApplicationPresenter
     # We do not use the 'sign' instance here, because we want this cache
     # to not expire unless the variation key changes. If we use the sign instance,
     # the cache expires each time the sign is changed at all.
-    Rails.cache.fetch([:signs, sign.id, :poster_url, preview.variation.key], expires_in: 5.days) do
-      preview.processed.service_url(expires_in: 1.week) # The maximum permitted
+    Rails.cache.fetch([:signs, sign.id, :poster_url, preview.variation.key]) do
+      preview.processed # Ensure the preview is processed
+      h.url_for(preview.image)
     end
   end
 

--- a/spec/presenters/sign_presenter_spec.rb
+++ b/spec/presenters/sign_presenter_spec.rb
@@ -164,14 +164,13 @@ RSpec.describe SignPresenter, type: :presenter do
           .with(ThumbnailPreset.default.scale_1080.to_h)
           .and_return(preview)
 
-        expect(preview).to receive(:service_url).and_return("/preview-url")
-
+        expect(view).to receive(:url_for).with(preview.image).and_return("/preview-url")
         expect(presenter.poster_url).to eq "/preview-url"
       end
 
       it "requests a video preview with the given size" do
         preview = double.as_null_object
-        expect(preview).to receive(:service_url).and_return("/preview-url")
+        expect(view).to receive(:url_for).with(preview.image).and_return("/preview-url")
 
         expect(sign.video).to receive(:preview)
           .with(ThumbnailPreset.default.scale_720.to_h)


### PR DESCRIPTION
The previous implementation used service_url, which automatically
generates a presigned URL that expires after 5 minutes. This causes
chaos with caching, as sign card are cached with expired thumbnail URLs.