### PR TITLE
Add touch: true to FolderMembership and SignTopic join tables so that the sign cache is expired when signs are added to folders or topics

### DIFF
--- a/app/models/folder_membership.rb
+++ b/app/models/folder_membership.rb
@@ -1,6 +1,6 @@
 class FolderMembership < ApplicationRecord
   belongs_to :folder, counter_cache: :signs_count
-  belongs_to :sign
+  belongs_to :sign, touch: true
 
   scope :owner_of, lambda { |sign|
     joins(:folder).where(sign_id: sign.id, folders: { user_id: sign.contributor_id })

--- a/app/models/sign_topic.rb
+++ b/app/models/sign_topic.rb
@@ -1,4 +1,4 @@
 class SignTopic < ApplicationRecord
   belongs_to :topic
-  belongs_to :sign
+  belongs_to :sign, touch: true
 end


### PR DESCRIPTION
This fixes an issue that I noticed where adding a sign to a folder uses JS to record that a sign was added to a folder, but subsequent page reloads don't reflect that the sign is in a folder. 
This is happening because folder adds are not touching the sign, therefore the cache stores an incorrect state for the given sign & user card.