### PR TITLE
What was I thinking? Don't cache the result of a helper! 

### DIFF
--- a/app/helpers/signs_helper.rb
+++ b/app/helpers/signs_helper.rb
@@ -1,36 +1,32 @@
 module SignsHelper
   def agree_button(sign, extra_classes="grid-x align-middle", &block)
-    Rails.cache.fetch([sign, current_user, :agree_button]) do
-      classes = "sign-card__votes--agree #{extra_classes}"
-      next content_tag(:div, class: classes, &block) unless policy(sign).agree?
+    classes = "sign-card__votes--agree #{extra_classes}"
+    return content_tag(:div, class: classes, &block) unless policy(sign).agree?
 
-      if SignActivity.agree?(sign_id: sign.id, user: current_user)
-        classes << " sign-card__votes--agreed"
-        next undo_agree_button(sign, classes, &block)
-      end
-
-      link_to(sign_agreement_path(sign), method: :post,
-                                         title: "Agree",
-                                         data: { remote: true },
-                                         class: classes, &block)
+    if SignActivity.agree?(sign_id: sign.id, user: current_user)
+      classes << " sign-card__votes--agreed"
+      return undo_agree_button(sign, classes, &block)
     end
+
+    link_to(sign_agreement_path(sign), method: :post,
+                                       title: "Agree",
+                                       data: { remote: true },
+                                       class: classes, &block)
   end
 
   def disagree_button(sign, extra_classes="grid-x align-middle", &block)
-    Rails.cache.fetch([sign, current_user, :disagree_button]) do
-      classes = "sign-card__votes--disagree #{extra_classes}"
-      next content_tag(:div, class: classes, &block) unless policy(sign).disagree?
+    classes = "sign-card__votes--disagree #{extra_classes}"
+    return content_tag(:div, class: classes, &block) unless policy(sign).disagree?
 
-      if SignActivity.disagree?(sign_id: sign.id, user: current_user)
-        classes << " sign-card__votes--disagreed"
-        next undo_disagree_button(sign, classes, &block)
-      end
-
-      link_to(sign_disagreement_path(sign), method: :post,
-                                            data: { remote: true },
-                                            title: "Disagree",
-                                            class: classes, &block)
+    if SignActivity.disagree?(sign_id: sign.id, user: current_user)
+      classes << " sign-card__votes--disagreed"
+      return undo_disagree_button(sign, classes, &block)
     end
+
+    link_to(sign_disagreement_path(sign), method: :post,
+                                          data: { remote: true },
+                                          title: "Disagree",
+                                          class: classes, &block)
   end
 
   def undo_agree_button(sign, classes, &block)


### PR DESCRIPTION
It's a helper - it's shared and yields different content depending on the block that is passed in. In this case, the vote buttons on a sign _card_ just have the count next to the agree/disagree buttons (a tick and cross icon respectively).On the sign _show page), the vote buttons have the words "{{count}} Agree"/"{{count}} Disagree". If the show page got hit before a sign card, then the wrong thing was cached. 