### PR TITLE
ci: ignore unpatchable vulnerabilities for now

### DIFF
--- a/bin/ci-run
+++ b/bin/ci-run
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-bundle exec bundle-audit --update
+bundle exec bundle-audit --update --ignore CVE-2021-22904 CVE-2021-22902 CVE-2021-22885
 bundle exec brakeman --run-all-checks --exit-on-warn .
 bundle exec rake
 bin/lint-styles


### PR DESCRIPTION
These require updating `administrate`: #360
The `puma` vulnerability will be patched by #363 
