### PR TITLE
revert the video_attributes change I made in the other CCSD-2064 branch

### DIFF
--- a/app/views/signs/card/_attachment.html.erb
+++ b/app/views/signs/card/_attachment.html.erb
@@ -1,6 +1,6 @@
 <% overlay ||= true %>
 <div class="video-wrapper" <%= "data-overlay" if overlay %>>
-  <%= content_tag :video, @sign.sign_video_attributes do %>
+  <%= content_tag :video, video_attributes.merge(class: "video has-video") do %>
     <%= video_sourceset(attachment) %>
   <% end %>
 


### PR DESCRIPTION
revert the video_attributes change I made in the other CCSD-2064 branch because its SUPPOSED to not have thumbnails. The change made it have the wrong thumbnails