### PR TITLE
increase capybara wait time from 5 to 15 seconds

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -38,7 +38,7 @@ rescue ActiveRecord::PendingMigrationError => e
   exit 1
 end
 
-Capybara.default_max_wait_time = 5.seconds # Default is 2 seconds
+Capybara.default_max_wait_time = 15.seconds # Default is 2 seconds
 Capybara.register_driver :chrome do |app|
   options = Selenium::WebDriver::Chrome::Options.new
 


### PR DESCRIPTION
Increase the capybara maximum wait time from 5 to 15 seconds, just in
case codeship CI is having a slow day