### PR TITLE
chore: rename "Unknown Contributor" to have a valid username

### DIFF
--- a/db/migrate/20191003003039_add_contributor_to_signs.rb
+++ b/db/migrate/20191003003039_add_contributor_to_signs.rb
@@ -6,7 +6,7 @@ class AddContributorToSigns < ActiveRecord::Migration[6.0]
                   :contributor, null: true,
                                 foreign_key: { to_table: :users }
 
-    user = User.where(username: "Unknown Contributor")
+    user = User.where(username: "unknowncontributor")
                .first_or_initialize
                .tap { |u| u.save(validate: false) }
     Sign.where(contributor: nil).update_all(contributor_id: user.id)


### PR DESCRIPTION
This users name was invalid, meaning it'd cause errors if we tried to link to their user profile.

So far this has only seemed to occur once, on UAT where someone had associated a comment to this user - while I believe that was an invalid state that could only be achieved via the rails console, for safety we've renamed the user to have a valid username after discussion with the client.

For safety and ease of conscience, I'm renaming the single reference to that username :)