### PR TITLE
test: disable animations to make things a little faster

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -39,6 +39,7 @@ rescue ActiveRecord::PendingMigrationError => e
 end
 
 Capybara.default_max_wait_time = 15.seconds # Default is 2 seconds
+Capybara.disable_animation = true
 Capybara.register_driver :chrome do |app|
   options = Selenium::WebDriver::Chrome::Options.new
 


### PR DESCRIPTION
This probably won't too much of a difference, but the test suite typically takes 30-40 minutes to run so any speedup is a gain at this point.