### PR TITLE
fix: enable csrf protection for create route

### DIFF
--- a/app/controllers/sign_video_comment_controller.rb
+++ b/app/controllers/sign_video_comment_controller.rb
@@ -1,7 +1,6 @@
 class SignVideoCommentController < ApplicationController
   include ActionView::RecordIdentifier
 
-  protect_from_forgery except: :create
   before_action :authenticate_user!
   after_action :post_process, only: :create
 

--- a/app/frontend/components/video-comment.js
+++ b/app/frontend/components/video-comment.js
@@ -34,6 +34,10 @@ const handleCommentReplyAttachmentUpload = ($container) => {
   const signedBlobId = $field.val();
   const folderId = $container.data("folderId");
 
+  $.ajaxSetup({
+    headers: { "X-CSRF-TOKEN": $("meta[name='csrf-token']").attr("content") }
+  });
+
   // eslint-disable-next-line camelcase
   return $.post(`/signs/${signId}/video_comment`, { signed_blob_id: signedBlobId, parent_id: parentId, folder_id: folderId, format: "js" })
     .done(() => {


### PR DESCRIPTION
This was added in https://github.com/ackama/nzsl-share/commit/3b4d2d441b0177046f68b8e283e3c8cacd099ba4 though I can't see any strong reason why so am going to see what happens if we just remove it.

(this is being flagged by https://github.com/ackama/nzsl-share/pull/452 which I'd really like to land, but want a better understanding before I mark it as ignored)