### PR TITLE
Add Aptfile to install SQLite3 dev dependencies

### DIFF
--- a/Aptfile
+++ b/Aptfile
@@ -1,0 +1,5 @@
+# This application pulls dictionary data from a static, readonly SQLite database
+# located at db/dictionary.sqlite3. Heroku doesn't include SQLite3, so we must install
+# the dev packages required to install the sqlite3 gem with native extensions:
+libsqlite3-dev
+libsqlite3-0


### PR DESCRIPTION
Heroku doesn't include SQLite dev packages. [They](https://devcenter.heroku.com/articles/sqlite3) and [everyone](https://stackoverflow.com/questions/66839571/how-to-use-sqlite-on-heroku) [else](https://stackoverflow.com/questions/31395856/django-deploying-an-application-on-heroku-with-sqlite3-as-the-database)  is adamant that it's not a good idea. 

In our case, we definitely want to do this. We have a bunch of relational data from Signbank, which we want to update every now and then, but not from within this application. SQLite gives us a performant data source for this data, with the ability to have relations between glosses, video and imagery information, as well as the ability to use native ActiveRecord mechanisms to access this data.

Fortunately, HashRocket has already had the same problem, and posted a [TIL](https://til.hashrocket.com/posts/ag0xy7ypj1-how-to-install-sqlite3-on-heroku) about how to do it - add the apt buildpack, and then include an Aptfile that will install the dev packages required to install the SQLite3 gem.

I've already enabled the buildpack for UAT and production, so committing this file will just cause those packages to be installed on build.