### PR TITLE
NZSL-47: Update dictionary when web or worker processes start

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,4 +48,4 @@ yarn-debug.log*
 # for dev use, even if it's out of date. We also update the dictionary file each
 # time bin/setup or rake dictionary:update is run, and automatically download
 # the latest version when we start deployed dynos.
-/db/nzsl-signbank.db.sqlite3
+/db/nzsl-dictionary.db.sqlite3

--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,11 @@ yarn-debug.log*
 /config/master.key
 /.env
 .DS_Store
+
+# Ignore subsequent changes to the dictionary SQLite file. Because git treats
+# SQLite as a binary format, every change to this file stores a new copy of the
+# file. To reduce churn, we package a copy of the dictionary that is sufficient
+# for dev use, even if it's out of date. We also update the dictionary file each
+# time bin/setup or rake dictionary:update is run, and automatically download
+# the latest version when we start deployed dynos.
+/db/nzsl-signbank.db.sqlite3

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,8 +43,8 @@ bin/setup
 This project follows the typical structure for a Rails application: generally, application code is located in `app`
 and tests are in `spec`. Other locations of interest include:
 
-* `app/frontend` - our webpacker directory (we don't have app/assets)
-* `lib` - some additional files that are tangentially related to the application
+- `app/frontend` - our webpacker directory (we don't have app/assets)
+- `lib` - some additional files that are tangentially related to the application
 
 There are other files in the project, of course, but these are likely the ones
 you'll be most interested in.
@@ -56,11 +56,11 @@ appropriate. We aim to keep classes as single-responsibility as we can.
 
 In addition, tests are broken up into two categories:
 
-* Unit tests — low-level tests for individual classes. These tests typically stub out arguments and dependencies
+- Unit tests — low-level tests for individual classes. These tests typically stub out arguments and dependencies
   that an object has.
-* Integration tests — high-level tests to ensure that the application works. We don't have many of these tests, as
+- Integration tests — high-level tests to ensure that the application works. We don't have many of these tests, as
   we just use them to fill in gaps between system and unit tests (for example, API-only controllers).
-* System tests - behaviour-driven tests, driven by Capybara through either Rack::Test or Google Chrome. Only use
+- System tests - behaviour-driven tests, driven by Capybara through either Rack::Test or Google Chrome. Only use
   Chrome if you absolutely need it, as it's the slowest type of test we have.
 
 Our approach to testing tends to iterate over time. The best approach for writing tests is to copy an existing test in the same file as where you want to add a new test. We may suggest changes to bring the tests in line with
@@ -72,11 +72,11 @@ We follow a derivative of the [unofficial Ruby style guide] created by the
 Rubocop developers. You can view our Rubocop configuration [here], but here are
 some key differences:
 
-* We allow longer blocks in spec files. This is because `RSpec.describe` blocks can
+- We allow longer blocks in spec files. This is because `RSpec.describe` blocks can
   quite easily go over the default Rubocop limit.
-* We have increased the maximum line length to 100 characters.
+- We have increased the maximum line length to 100 characters.
 
-[unofficial Ruby style guide]: https://github.com/rubocop-hq/ruby-style-guide
+[unofficial ruby style guide]: https://github.com/rubocop-hq/ruby-style-guide
 [here]: .rubocop.yml
 
 We also follow the core ESLint and SASS-Lint style guides, and these processes are all
@@ -131,11 +131,10 @@ In order to run all of the tests, simply run:
 bundle exec rake
 ```
 
-
 ## Managing your branch
 
-* Use well-crafted commit messages, providing context if possible.
-* Squash "WIP" commits and remove merge commits by rebasing your branch against
+- Use well-crafted commit messages, providing context if possible.
+- Squash "WIP" commits and remove merge commits by rebasing your branch against
   `master`. We try to keep our commit history as clean as possible.
 
 ## Documentation
@@ -146,13 +145,12 @@ are prefaced with inline documentation.
 If your changes end up extending or updating the API, it helps greatly to update the
 docs at the same time for future developers and other readers of the source code.
 
-
 ## Continuous integration
 
 While running `bundle exec rake` is a great way to check your work, this command
 will only run your tests against the latest supported Ruby and Rails version.
 Ultimately, though, you'll want to ensure that your changes work in all possible
-environments. We make use of [Codeship][codeship] to do this work for us. Codeship
+environments. We make use of [Github Actions](https://github.com/ackama/nzsl-share/actions) to do this work for us. Actions
 will kick in after you push up a branch or open a PR. It takes about 20 minutes to
 run a complete build.
 
@@ -160,5 +158,3 @@ What happens if the build fails in some way? Don't fear! Click on a failed job
 and scroll through its output to determine the cause of the failure. You'll want
 to make changes to your branch and push them up until the entire build is green.
 It may take a bit of time, but overall it is worth it and it helps us immensely!
-
-[travis]: https://codeship.io

--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,3 @@
-web:     bundle exec puma -C config/puma.rb
-worker:  bundle exec sidekiq -C config/sidekiq.yml
+web:     (bundle exec rake dictionary:update || true) && bundle exec puma -C config/puma.rb
+worker:  (bundle exec rake dictionary:update || true) && bundle exec sidekiq -C config/sidekiq.yml
 release: bundle exec rake db:migrate db:seed

--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,3 @@
-web:     (bundle exec rake dictionary:update || true) && bundle exec puma -C config/puma.rb
-worker:  (bundle exec rake dictionary:update || true) && bundle exec sidekiq -C config/sidekiq.yml
-release: bundle exec rake db:migrate db:seed
+web:     bundle exec rake dictionary:update && bundle exec puma -C config/puma.rb
+worker:  bundle exec rake dictionary:update && bundle exec sidekiq -C config/sidekiq.yml
+release: bundle exec rake db:migrate db:seed dictionary:update

--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,3 @@
 web:     bundle exec rake dictionary:update && bundle exec puma -C config/puma.rb
 worker:  bundle exec rake dictionary:update && bundle exec sidekiq -C config/sidekiq.yml
-release: bundle exec rake db:migrate db:seed dictionary:update
+release: bundle exec rake dictionary:update && bundle exec rake db:migrate db:seed

--- a/README.md
+++ b/README.md
@@ -39,11 +39,11 @@ If you know what you're doing already, `bin/setup` should get you set up, and yo
 This application allows users to search for signs that are already published in the
 [NZSL Dictionary](https://nzsl.nz). This reduces the risk that a contribution duplicates already-published work.
 
-The dictionary data is consumed from a SQLite database that is included with this repository. From time to time, the dictionary data is updated, and exported by [nzsl-dictionary-scripts](https://github.com/odnzsl/nzsl-dictionary-scripts).
+The dictionary data is consumed from a SQLite database that is downloaded from a Github release. From time to time, the dictionary data is updated, and exported by [nzsl-dictionary-scripts](https://github.com/odnzsl/nzsl-dictionary-scripts).
 
-Unless there has been a major change to published data, **you don't need to update the dictionary SQLite file**. The copy published in the repository is sufficient to get started, and `bin/setup` fetches the most recent copy for you. Additionally, when the application is started after each deploy, the most recent copy is also downloaded in staging and production.
+Unless there has been a major change to published data, **you don't need to update the dictionary SQLite file often**. Running `bin/setup` fetched the most recent copy for you during application setup. Additionally, when the application is started after each deploy, the most recent copy is also downloaded in staging and production.
 
-If you know there has been an update, and want the latest copy, you can run `bundle exec rake dictionary:update` to download it. If this change introduces schema or key data changes that are required for NZSL Share development, you can force-add the file to update it.
+If you know there has been an update, and want the latest copy, you can run `bundle exec rake dictionary:update` to download it.
 
 ## Deployment
 

--- a/README.md
+++ b/README.md
@@ -8,18 +8,19 @@ This is a Rails 6 app.
 
 This README describes the purpose of this repository and how to set up a development environment. Other sources of documentation are as follows:
 
-* UI and API designs are in `doc/`
-* A playbook for failure scenarios and what to do can be found in `doc/playbook.md`
-* The authorisation policy for this app can also be found in `doc/` - this details the types of users and the permissions they have.
+- UI and API designs are in `doc/`
+- A playbook for failure scenarios and what to do can be found in `doc/playbook.md`
+- The authorisation policy for this app can also be found in `doc/` - this details the types of users and the permissions they have.
 
 ## Prerequisites
 
 This project requires:
 
-* Ruby 2.7.4, preferably managed using [rbenv][]
-* Google Chrome for headless Capybara testing
-* PostgreSQL must be installed and accepting connections
-* Redis must be installed and accepting connections
+- Ruby 2.7.4, preferably managed using [rbenv][]
+- Google Chrome for headless Capybara testing
+- PostgreSQL must be installed and accepting connections
+- SQLite must be installed with development libraries to connect to the dictionary database
+- Redis must be installed and accepting connections
 
 On a Mac, you can obtain all of the above packages using [Homebrew][].
 
@@ -33,40 +34,51 @@ and contributing to the project!
 If you know what you're doing already, `bin/setup` should get you set up, and you can run
 `bin/ci-run` to make sure you've got locally passing tests.
 
+## Signbank Dictionary
+
+This application allows users to search for signs that are already published in the
+[NZSL Dictionary](https://nzsl.nz). This reduces the risk that a contribution duplicates already-published work.
+
+The dictionary data is consumed from a SQLite database that is included with this repository. From time to time, the dictionary data is updated, and exported by [nzsl-dictionary-scripts](https://github.com/odnzsl/nzsl-dictionary-scripts).
+
+Unless there has been a major change to published data, **you don't need to update the dictionary SQLite file**. The copy published in the repository is sufficient to get started, and `bin/setup` fetches the most recent copy for you. Additionally, when the application is started after each deploy, the most recent copy is also downloaded in staging and production.
+
+If you know there has been an update, and want the latest copy, you can run `bundle exec rake dictionary:update` to download it. If this change introduces schema or key data changes that are required for NZSL Share development, you can force-add the file to update it.
+
 ## Deployment
 
 Ensure the following environment variables are set in the deployment environment to configure
 the environment. Other, application-specific configuration keys can be found in `example.env`.
 
-* `RACK_ENV`
-* `RAILS_ENV`
-* `REDIS_URL`
-* `SECRET_KEY_BASE`
-* `SIDEKIQ_WEB_PASSWORD`
-* `SIDEKIQ_WEB_USERNAME`
+- `RACK_ENV`
+- `RAILS_ENV`
+- `REDIS_URL`
+- `SECRET_KEY_BASE`
+- `SIDEKIQ_WEB_PASSWORD`
+- `SIDEKIQ_WEB_USERNAME`
 
 Optionally:
 
-* `HOSTNAME`
-* `RAILS_FORCE_SSL`
-* `RAILS_LOG_TO_STDOUT`
-* `RAILS_MAX_THREADS`
-* `RAILS_SERVE_STATIC_FILES`
-* `WEB_CONCURRENCY`
+- `HOSTNAME`
+- `RAILS_FORCE_SSL`
+- `RAILS_LOG_TO_STDOUT`
+- `RAILS_MAX_THREADS`
+- `RAILS_SERVE_STATIC_FILES`
+- `WEB_CONCURRENCY`
 
-[rbenv]:https://github.com/sstephenson/rbenv
-[redis]:http://redis.io
-[Homebrew]:http://brew.sh
+[rbenv]: https://github.com/sstephenson/rbenv
+[redis]: http://redis.io
+[homebrew]: http://brew.sh
 
 ## Browser support
 
 We support the latest 2 versions (stable releases) of major browsers for desktop and mobile. At the time of writing this is:
 
-| Browser       | Desktop     | iOS    | Android |
-| ------------- |-------------| -------| --------|
-| Chrome        | 76, 75      | 76, 75 | 76, 75  |
-| Edge          | 17, 16      | N/A    | 15, 14  |
-| Firefox       | 69, 68      | 18, 17 | 68, 67  |
-| Safari        | 13, 12      | 12, 11 | N/A     |
+| Browser | Desktop | iOS    | Android |
+| ------- | ------- | ------ | ------- |
+| Chrome  | 76, 75  | 76, 75 | 76, 75  |
+| Edge    | 17, 16  | N/A    | 15, 14  |
+| Firefox | 69, 68  | 18, 17 | 68, 67  |
+| Safari  | 13, 12  | 12, 11 | N/A     |
 
 You can check the versions covered by our `browserslist` configuration [here](https://browserl.ist/?q=%3E+0.25%25+in+NZ+and+last+2+versions%2C+not+ie+11%2C+not+op_mini+all)

--- a/bin/setup
+++ b/bin/setup
@@ -11,11 +11,11 @@ def setup!
     copy "config/database.example.yml"
     copy "config/secrets.example.yml"
     test_local_env_contains_required_keys
+    run  "bin/rake dictionary:update"
     run  "bin/rake tmp:create"
     run  "bin/rake db:create:all"
     run  "bin/rake db:migrate"
     run  "bin/rake db:seed"
-    run  "bin/rake dictionary:update"
   end
 end
 

--- a/bin/setup
+++ b/bin/setup
@@ -15,6 +15,7 @@ def setup!
     run  "bin/rake db:create:all"
     run  "bin/rake db:migrate"
     run  "bin/rake db:seed"
+    run  "bin/rake dictionary:update"
   end
 end
 

--- a/lib/tasks/dictionary.rake
+++ b/lib/tasks/dictionary.rake
@@ -19,8 +19,8 @@ namespace :dictionary do
     database = SQLite3::Database.open("db/new-dictionary.sqlite3")
     fail "Database does not pass integrity check" unless database.integrity_check == [["ok"]]
 
-    FileUtils.mv("db/new-dictionary.sqlite3", "db/dictionary.sqlite3")
+    FileUtils.mv("db/new-dictionary.sqlite3", "db/nzsl-dictionary.db.sqlite3")
 
-    puts "Updated db/dictionary.sqlite3 to #{release["name"]}"
+    puts "Updated db/nzsl-dictionary.db.sqlite3 to #{release["name"]}"
   end
 end

--- a/lib/tasks/dictionary.rake
+++ b/lib/tasks/dictionary.rake
@@ -1,0 +1,26 @@
+namespace :dictionary do
+  desc "Updates the NZSL dictionary packaged with the application to the latest release from Signbank"
+  task update: :environment do
+    repo = "odnzsl/nzsl-dictionary-scripts"
+    filename = "nzsl.db"
+    content_type = "application/vnd.sqlite3"
+    release_uri = URI::HTTPS.build(host: "api.github.com", path: "/repos/#{repo}/releases/latest")
+    release = JSON.parse(release_uri.open.read)
+    database_asset = release["assets"].find do |asset|
+      asset["name"] == filename && asset["content_type"] == content_type
+    end
+
+    database_url = database_asset.fetch("browser_download_url")
+
+    File.open("db/new-dictionary.sqlite3", "wb") do |f|
+      f.write URI.parse(database_url).open.read
+    end
+
+    database = SQLite3::Database.open("db/new-dictionary.sqlite3")
+    fail "Database does not pass integrity check" unless database.integrity_check == [["ok"]]
+
+    FileUtils.mv("db/new-dictionary.sqlite3", "db/dictionary.sqlite3")
+
+    puts "Updated db/dictionary.sqlite3 to #{release["name"]}"
+  end
+end

--- a/lib/tasks/dictionary.rake
+++ b/lib/tasks/dictionary.rake
@@ -11,10 +11,7 @@ namespace :dictionary do
     end
 
     database_url = database_asset.fetch("browser_download_url")
-
-    File.open("db/new-dictionary.sqlite3", "wb") do |f|
-      f.write URI.parse(database_url).open.read
-    end
+    File.binwrite("db/new-dictionary.sqlite3", URI.parse(database_url).open.read)
 
     database = SQLite3::Database.open("db/new-dictionary.sqlite3")
     fail "Database does not pass integrity check" unless database.integrity_check == [["ok"]]

--- a/lib/tasks/dictionary.rake
+++ b/lib/tasks/dictionary.rake
@@ -1,6 +1,6 @@
 namespace :dictionary do
   desc "Updates the NZSL dictionary packaged with the application to the latest release from Signbank"
-  task update: :environment do
+  task :update do # rubocop:disable Rails/RakeEnvironment - we need to place this file before the app can start
     repo = "odnzsl/nzsl-dictionary-scripts"
     filename = "nzsl.db"
     content_type = "application/vnd.sqlite3"


### PR DESCRIPTION
This pull request adds a simple rake task to update the dictionary file stored in the repo to the latest version each time a web or worker dyno starts. I've tried to make this fault tolerant; that is, if anything goes wrong updating the dictionary DB, it falls back to the latest version (this uses some shell magic, which I've tested using `foreman start`, and I assume Heroku will handle this as well). 

In the future, we could move this into Github Actions. This would be nice because we would track changes to the dictionary, be able to PR changes, etc, however there's quite a high risk that we could quickly bloat the repo, since git treats SQLite as a binary file, so keeps a full copy of the file for each commit. For now, we're going to stick with this approach, since it allows us to play around with different techniques without affecting the repo. I've added the SQLite file to gitignore as well, which will make it harder for a dev to accidentally commit a modified database. Instead, the idea is that devs can use the packaged database, even if it is outdated. When the project is set up, the latest release is downloaded, and devs can manually update their database any time using the rake task.

The script is somewhat defensive - it only moves the new database into place once the file has downloaded, and passes a SQLite integrity check, which checks that all relations and other DB objects are valid. If anything goes wrong any time before that, it doesn't do anything other than raise an error.

I also reviewed and updated the documentation around data from Signbank.