### PR TITLE
NZSL-69: Retain the folder a comment is in when it is edited

### DIFF
--- a/app/controllers/sign_comments_controller.rb
+++ b/app/controllers/sign_comments_controller.rb
@@ -68,9 +68,9 @@ class SignCommentsController < ApplicationController
   def build_text_comment
     {
       comment: Sanitizer.sanitize_text_with_urls(comment_params[:comment]),
-      parent_id: comment_params[:parent_id],
       anonymous: comment_params[:anonymous],
-      folder_id: comment_params[:folder_id],
+      parent_id: @sign_comment&.parent_id || comment_params[:parent_id],
+      folder_id: @sign_comment&.folder_id || comment_params[:folder_id],
       sign_status: @sign.status,
       sign: @sign,
       user: current_user

--- a/spec/requests/sign_comment_spec.rb
+++ b/spec/requests/sign_comment_spec.rb
@@ -105,6 +105,15 @@ RSpec.describe "sign_comment", type: :request do
         expect(sign.sign_comments.first.comment).to eq "updated comment"
         expect(response).to redirect_to sign_path(sign, anchor: "sign_comment_#{sign.sign_comments.first.id}")
       end
+
+      it "retains the folder context of a comment" do
+        folder = FactoryBot.create(:folder)
+        create_params[:folder_id] = folder.id
+        create.call(sign)
+        comment = sign.sign_comments.last
+        update.call(sign, comment)
+        expect { comment.reload }.not_to change(comment, :folder).from(folder)
+      end
     end
 
     describe "reply" do


### PR DESCRIPTION
This bug occurs because the folder ID was reset when the edit comment form was submitted, since it didn't include the current folder ID. Rather than add a hidden field, I've opted to pull the folder ID from the existing comment, to avoid params tampering. 


https://user-images.githubusercontent.com/292020/207740037-3c6389e7-58ca-4a42-b05f-517cfabe61a7.mp4

