### PR TITLE
NZSL-63: Filter sign moderation to pending signs by default

### DIFF
--- a/app/controllers/admin/signs_controller.rb
+++ b/app/controllers/admin/signs_controller.rb
@@ -2,6 +2,11 @@
 
 module Admin
   class SignsController < Admin::ApplicationController
+    def index
+      params[:search] ||= "pending:"
+      super
+    end
+
     def scoped_resource
       policy_scope(Sign).where.not(status: :personal)
     end

--- a/spec/system/edit_sign_feature_spec.rb
+++ b/spec/system/edit_sign_feature_spec.rb
@@ -146,7 +146,7 @@ RSpec.describe "Editing a sign", type: :system do
 
     context "when the sign video has had thumbnails generated" do
       before { sign.update!(processed_thumbnails: true); }
-      it { expect(page).to have_selector ".video[poster*='/rails/active_storage/']" }
+      it { expect(page).to have_selector(".video[poster*='/rails/active_storage/']", wait: 30.seconds) }
     end
 
     context "when the sign video has been encoded" do

--- a/spec/system/sign_moderation_spec.rb
+++ b/spec/system/sign_moderation_spec.rb
@@ -11,6 +11,10 @@ RSpec.describe "Sign moderation", type: :system do
   it_behaves_like "an Administrate dashboard", :signs, except: %i[destroy new show]
 
   context "filtering" do
+    it "defaults to the 'pending' filter" do
+      expect(page).to have_field "search", with: "pending:"
+    end
+
     context "using dropdown" do
       it "filters by Pending" do
         select "Pending", from: "status"

--- a/spec/system/sign_moderation_spec.rb
+++ b/spec/system/sign_moderation_spec.rb
@@ -5,12 +5,13 @@ RSpec.describe "Sign moderation", type: :system do
   let(:moderator) { FactoryBot.create(:user, :moderator) }
   let!(:signs) { FactoryBot.create_list(:sign, 3, :published) }
 
-  before { visit_admin(:signs, admin: moderator) }
+  before { visit_admin("signs?search=published:", admin: moderator) }
 
   it_behaves_like "an Administrate dashboard", except: %i[destroy new show]
 
   context "filtering" do
     it "defaults to the 'pending' filter" do
+      visit_admin(:signs, admin: moderator)
       expect(page).to have_field "search", with: "pending:"
     end
 


### PR DESCRIPTION
This pull request adds a default filter for `admin/signs#index`. There are a number of ways to accomplish this, but I've tried to put this in the most obvious place, which is the controller action. This causes the pending search filter to be applied, meaning that by default, an administrator will only see signs that require some action.


https://user-images.githubusercontent.com/292020/207745241-eb5e8860-5686-4373-8812-26f9cda79b0f.mp4

