### PR TITLE
NZSL-84 mod redirect error

### DIFF
--- a/app/controllers/sign_workflow_controller.rb
+++ b/app/controllers/sign_workflow_controller.rb
@@ -8,7 +8,7 @@ class SignWorkflowController < ApplicationController
 
   def unpublish
     sign.unpublish!
-    succeeded
+    succeeded(redirect_back: false)
   end
 
   def cancel_submit
@@ -28,7 +28,7 @@ class SignWorkflowController < ApplicationController
 
   def decline
     sign.decline!
-    succeeded
+    succeeded(redirect_back: false)
   end
 
   # Unused - this transition is invoked from the
@@ -42,8 +42,19 @@ class SignWorkflowController < ApplicationController
 
   private
 
-  def succeeded
-    redirect_back(fallback_location: sign, notice: success_messsage)
+  def succeeded(redirect_back: true)
+    if redirect_back
+      redirect_back(fallback_location: redirect_location, notice: success_messsage)
+    else
+      redirect_to redirect_location, notice: success_messsage
+    end
+  end
+
+  def redirect_location
+    return sign if policy(sign).show?
+    return admin_signs_path if current_user.administrator? || current_user.moderator?
+
+    public_signs_path
   end
 
   def success_messsage

--- a/app/controllers/sign_workflow_controller.rb
+++ b/app/controllers/sign_workflow_controller.rb
@@ -8,7 +8,7 @@ class SignWorkflowController < ApplicationController
 
   def unpublish
     sign.unpublish!
-    succeeded(redirect_back: false)
+    succeeded(redirect_path: redirect_location)
   end
 
   def cancel_submit
@@ -28,7 +28,7 @@ class SignWorkflowController < ApplicationController
 
   def decline
     sign.decline!
-    succeeded(redirect_back: false)
+    succeeded(redirect_path: redirect_location)
   end
 
   # Unused - this transition is invoked from the
@@ -42,11 +42,11 @@ class SignWorkflowController < ApplicationController
 
   private
 
-  def succeeded(redirect_back: true)
-    if redirect_back
-      redirect_back(fallback_location: redirect_location, notice: success_messsage)
+  def succeeded(redirect_path: nil)
+    if redirect_path
+      redirect_to redirect_path, notice: success_messsage
     else
-      redirect_to redirect_location, notice: success_messsage
+      redirect_back(fallback_location: redirect_location, notice: success_messsage)
     end
   end
 

--- a/spec/system/sign_show_page_spec.rb
+++ b/spec/system/sign_show_page_spec.rb
@@ -154,7 +154,7 @@ RSpec.describe "Sign show page", system: true do
           end
         end
 
-        it "allows the moderator to manage the sign", uses_javascript: true do
+        it "allows the moderator to publish the sign", uses_javascript: true do
           within("#sign_overview") { expect(sign_page).to have_link "Edit" }
 
           my_link = find(:xpath, "//a[contains(@href,'signs/#{sign.id}/publish')]")
@@ -167,6 +167,21 @@ RSpec.describe "Sign show page", system: true do
           expect(subject).to have_content I18n.t!("sign_workflow.publish.success")
           sign.reload
           expect(sign.published?).to eq true
+        end
+
+        it "allows the moderator to decline the sign", uses_javascript: true do
+          within("#sign_overview") { expect(sign_page).to have_link "Edit" }
+
+          my_link = find(:xpath, "//a[contains(@href,'signs/#{sign.id}/decline')]")
+
+          my_link.click
+          alert = page.driver.browser.switch_to.alert
+
+          expect(alert.text).to eq I18n.t!("sign_workflow.decline.confirm")
+          alert.accept
+          expect(subject).to have_content I18n.t!("sign_workflow.decline.success")
+          sign.reload
+          expect(sign.declined?).to eq true
         end
       end
 


### PR DESCRIPTION
This PR fixes an error that occurred when redirecting after a moderator unpublishes or declines a sign. If a moderator performed these actions, the action is performed successfully but the app goes into a redirect loop. This happened because the app tried to redirect back to the sign after performing these actions, but the moderator no longer has permission to visit these signs. The code in ApplicationController that recovers from a permission error tries calling redirect_back. As redirect_back had a permission error that was attempted to be fixed by calling redirect_back, the app would get caught in an infinite loop.

This was fixed by updating the sign workflow controller so that the succeeded method can be passed a path. If a path is passed, then the app will try to redirect to the path instead of calling redirect_back. The path that is passed for both the decline and unpublish methods is resolved from a new method that gets a sensible path based on the permissions of the user. These are as follows:
- If the user can view the sign, redirect to the sign
- If the user is an admin or a moderator, redirect to the admin signs index
- Otherwise, redirect to the public signs index