### PR TITLE
NZSL-61: Add 'See all signs' button to the top of the topics index page

### DIFF
--- a/app/views/topics/index.html.erb
+++ b/app/views/topics/index.html.erb
@@ -13,6 +13,9 @@
   <div class="grid-x cell list">
     <div class="list__title list__section cell">
       <h1>Topics</h1>
+      <%= link_to(public_signs_path, class: "button royal primary") do %>
+        See all signs
+      <% end %>
     </div>
     <hr class="list__divider">
     <div class="list__section list__section--topics cell">

--- a/spec/system/topics_feature_spec.rb
+++ b/spec/system/topics_feature_spec.rb
@@ -13,6 +13,10 @@ RSpec.describe "Topics", type: :system do
     it "has the correct page title" do
       expect(page).to have_title "Topics – NZSL Share"
     end
+
+    it "has a link to view all signs" do
+      expect(page).to have_link "See all signs", href: public_signs_path
+    end
   end
 
   describe "show" do


### PR DESCRIPTION
This is the first and most obvious step of NZSL-61 - add a 'See all signs' button to the top of the topics index page. This helps with discoverability, since if someone can't find an appropriate topic, they've got an obvious way to see all the signs.

I'm expecting to add an 'Other' topic type thing for this feature as well.


![image](https://user-images.githubusercontent.com/292020/208317966-3f9d143b-2efc-4ac4-a4b7-7d131f6cb0c2.png)
