### PR TITLE
NZSL-59: Allow users to be deleted

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -10,6 +10,11 @@ module Admin
     #   send_foo_updated_email
     # end
 
+    def destroy
+      DeleteUserJob.perform_now(requested_resource)
+      redirect_to action: :index, notice: translate_with_resource("destroy.success")
+    end
+
     # Override this method to specify custom lookup behavior.
     # This will be used to set the resource for the `show`, `edit`, and `update`
     # actions.

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -12,7 +12,7 @@ module Admin
 
     def destroy
       DeleteUserJob.perform_now(requested_resource)
-      redirect_to action: :index, notice: translate_with_resource("destroy.success")
+      redirect_to admin_users_path, notice: translate_with_resource("destroy.success")
     end
 
     # Override this method to specify custom lookup behavior.

--- a/app/jobs/delete_user_job.rb
+++ b/app/jobs/delete_user_job.rb
@@ -1,0 +1,23 @@
+class DeleteUserJob < ApplicationJob
+  def perform(user)
+    return Rails.logger.error "Not deleting user #{user.to_gid} with signs" if user.signs.any?
+
+    User.transaction do
+      reallocate_shared_folders(user)
+      user.reload # Make sure that we don't destroy folders that have been reallocated
+
+      user.destroy
+    end
+  end
+
+  private
+
+  def reallocate_shared_folders(user)
+    user.folders.each do |folder|
+      next_collaborator = folder.collaborators.where.not(id: user).first
+      next unless next_collaborator
+
+      folder.update!(user: next_collaborator)
+    end
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -17,6 +17,8 @@ class User < ApplicationRecord
   has_many :signs, foreign_key: :contributor_id, inverse_of: :contributor, dependent: :nullify
   has_many :collaborations, foreign_key: :collaborator_id, inverse_of: :collaborator, dependent: :destroy
 
+  has_many :sign_comments, dependent: :nullify
+
   has_one :approved_user_application, dependent: :destroy
   has_one_attached :avatar
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -14,7 +14,7 @@ class User < ApplicationRecord
   attr_writer :login
 
   has_many :folders, dependent: :destroy
-  has_many :signs, foreign_key: :contributor_id, inverse_of: :contributor, dependent: :nullify
+  has_many :signs, foreign_key: :contributor_id, inverse_of: :contributor, dependent: :restrict_with_error
   has_many :collaborations, foreign_key: :collaborator_id, inverse_of: :collaborator, dependent: :destroy
 
   has_many :sign_comments, dependent: :nullify

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -11,6 +11,10 @@ class UserPolicy < ApplicationPolicy
     edit?
   end
 
+  def destroy?
+    administrator? && record.signs.empty?
+  end
+
   class Scope < Scope
     def resolve
       scope.all

--- a/app/views/admin/users/_collection.html.erb
+++ b/app/views/admin/users/_collection.html.erb
@@ -81,6 +81,14 @@ to display a collection of resources in an HTML table.
               <%= inline_svg_pack_tag "media/images/edit.svg" %><span>Edit</span>
             <% end %>
           </li>
+
+          <% if policy(resource).destroy? %>
+            <li class="list__item-menu__menu-item">
+              <%= link_to([namespace, resource], method: :delete, data: { confirm: t(".confirm_destroy")}) do %>
+                <%= inline_svg_pack_tag "media/images/close.svg" %><span>Delete</span>
+              <% end %>
+            </li>
+          <% end %>
         </ul>
       </div>
     <% end %>

--- a/app/views/sign_comments/shared/_comment.html.erb
+++ b/app/views/sign_comments/shared/_comment.html.erb
@@ -3,7 +3,7 @@
     <%= link_to "#" do %>
       <% inline_svg_pack_tag("media/images/avatar.svg", title: "Avatar", aria: true, class: "avatar avatar--small") %>
     <% end %>
-  <% else %>
+  <% elsif comment.user %>
     <%= link_to user_path(comment.user.username) do %>
       <%= comment.user_avatar %>
     <% end %>
@@ -12,9 +12,9 @@
 
 <div class="cell auto sign-comments__comment">
   <span class="cell auto">
-    <%= link_to user_path(comment.user.username), class: "sign-comments__comment__username--link" do %>
+    <%= link_to user_path(comment.user), class: "sign-comments__comment__username--link" do %>
       <%= comment.username %>
-    <% end unless comment.anonymous || comment.removed %>
+    <% end unless comment.anonymous || comment.removed || comment.user.nil? %>
   </span>
 
   <% if comment.removed? %>

--- a/app/views/sign_comments/shared/_options.html.erb
+++ b/app/views/sign_comments/shared/_options.html.erb
@@ -1,6 +1,6 @@
-<a href="#" data-toggle="<%= dom_id(comment, :options) %>" title="Comment Options">
+<button data-toggle="<%= dom_id(comment, :options) %>" title="Comment Options">
   <%= inline_svg_pack_tag "media/images/options.svg", class: "icon--medium list__item__icon" %>
-</a>
+</button>
 <div class="list__item-menu__dropdown-pane list__item-menu__dropdown-pane--admin"
      id="<%= dom_id(comment, :options) %>"
      data-position="bottom"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -176,6 +176,11 @@ en:
         link_to: Unpublish
         confirm: Make this sign private?
         success: Sign was made private # Pending message
+    users:
+      collection:
+        confirm_destroy: |
+          Are you sure you want to delete this user?
+          This will anonymise their comments, reallocate shared folders, and delete private folders.
   approved_user_mailer:
     admin_submitted:
       subject: NZSL Share Admin - Member application

--- a/db/migrate/20221218222106_allow_nil_sign_comments_user.rb
+++ b/db/migrate/20221218222106_allow_nil_sign_comments_user.rb
@@ -1,0 +1,5 @@
+class AllowNilSignCommentsUser < ActiveRecord::Migration[6.1]
+  def change
+    change_column_null :sign_comments, :user_id, from: false, to: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_11_28_080318) do
+ActiveRecord::Schema.define(version: 2022_12_18_222106) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -135,7 +135,7 @@ ActiveRecord::Schema.define(version: 2021_11_28_080318) do
   create_table "sign_comments", force: :cascade do |t|
     t.bigint "parent_id"
     t.bigint "sign_id", null: false
-    t.bigint "user_id", null: false
+    t.bigint "user_id"
     t.text "comment"
     t.text "sign_status", null: false
     t.boolean "display", default: true

--- a/spec/jobs/delete_user_job_spec.rb
+++ b/spec/jobs/delete_user_job_spec.rb
@@ -1,0 +1,37 @@
+require "rails_helper"
+
+RSpec.describe DeleteUserJob, type: :job do
+  let(:user) { FactoryBot.create(:user) }
+
+  subject(:perform) { described_class.perform_now(user) }
+
+  it "destroys the user" do
+    expect { perform }.to change(user, :persisted?).to(false)
+  end
+
+  it "skips a user that has signs" do
+    FactoryBot.create(:sign, contributor: user)
+    allow(Rails.logger).to receive(:error)
+    expect { perform }.not_to change(user, :persisted?)
+    expect(Rails.logger).to have_received(:error).with(/Not deleting user/)
+  end
+
+  it "leaves comments in place, but nullifies the user" do
+    comment = FactoryBot.create(:sign_comment, user: user)
+    expect { perform; comment.tap(&:reload) }.to change(comment, :user).from(user).to(nil)
+    expect(comment).to be_persisted
+  end
+
+  it "destroys an uncollaborated folder" do
+    FactoryBot.create(:folder, user: user)
+    expect { perform }.to change(Folder, :count).by(-1)
+  end
+
+  it "reallocates ownership of a folder with collaborators" do
+    collaborators = FactoryBot.create_list(:user, 2)
+    folder = FactoryBot.create(:folder, user: user)
+    folder.collaborators << collaborators
+    expect { perform }.not_to change(Folder, :count)
+    expect(folder.tap(&:reload).user).to eq collaborators.first
+  end
+end

--- a/spec/policies/user_policy_spec.rb
+++ b/spec/policies/user_policy_spec.rb
@@ -1,0 +1,46 @@
+require "rails_helper"
+
+RSpec.describe UserPolicy, type: :policy do
+  subject { described_class }
+
+  it "inherits from ApplicationPolicy" do
+    expect(described_class.superclass).to eq ApplicationPolicy
+  end
+
+  permissions :index?, :edit?, :update?, :destroy? do
+    let(:record) { User.new }
+
+    it "allows an administrator" do
+      user = User.new(administrator: true)
+      expect(subject).to permit(user, record)
+    end
+
+    it "does not allow a moderator" do
+      user = User.new(moderator: true)
+      expect(subject).not_to permit(user, record)
+    end
+
+    it "does not allow a validator" do
+      user = User.new(validator: true)
+      expect(subject).not_to permit(user, record)
+    end
+
+    it "does not allow a approved user" do
+      user = User.new(approved: true)
+      expect(subject).not_to permit(user, record)
+    end
+
+    it "does not a allow a user" do
+      user = User.new
+      expect(subject).not_to permit(user, record)
+    end
+  end
+
+  permissions :destroy? do
+    it "does not allow destroying a user who has contributed signs" do
+      sign = FactoryBot.create(:sign)
+      user = User.new(administrator: true)
+      expect(subject).not_to permit(user, sign.contributor)
+    end
+  end
+end

--- a/spec/requests/admin_users_spec.rb
+++ b/spec/requests/admin_users_spec.rb
@@ -1,0 +1,13 @@
+require "rails_helper"
+
+RSpec.describe "/admin/users", type: :request do
+  describe "DELETE destroy" do
+    it "destroys the user via DeleteUserJob" do
+      allow(DeleteUserJob).to receive(:perform_now)
+      user = FactoryBot.create(:user)
+      sign_in FactoryBot.build(:user, administrator: true)
+      delete admin_user_path(user)
+      expect(DeleteUserJob).to have_received(:perform_now).with(user)
+    end
+  end
+end

--- a/spec/requests/admin_users_spec.rb
+++ b/spec/requests/admin_users_spec.rb
@@ -9,5 +9,13 @@ RSpec.describe "/admin/users", type: :request do
       delete admin_user_path(user)
       expect(DeleteUserJob).to have_received(:perform_now).with(user)
     end
+
+    it "redirects with a success message" do
+      user = FactoryBot.create(:user)
+      sign_in FactoryBot.build(:user, administrator: true)
+      delete admin_user_path(user)
+      expect(response).to redirect_to admin_users_path
+      expect(flash[:notice]).to eq "User was successfully destroyed."
+    end
   end
 end

--- a/spec/support/shared_examples/administrate_shared_examples.rb
+++ b/spec/support/shared_examples/administrate_shared_examples.rb
@@ -38,7 +38,7 @@ RSpec.shared_examples "an Administrate dashboard" do |url_base, only: %i[index s
 
   if actions.include?(:destroy)
     it "can destroy a record", uses_javascript: true do
-      within(first_row) { click_on "Options" }
+      within(last_row) { click_on "Options" }
       within(".list__item-menu", match: :first) do
         accept_confirm do
           click_link("Delete")

--- a/spec/system/edit_sign_feature_spec.rb
+++ b/spec/system/edit_sign_feature_spec.rb
@@ -146,7 +146,7 @@ RSpec.describe "Editing a sign", type: :system do
 
     context "when the sign video has had thumbnails generated" do
       before { sign.update!(processed_thumbnails: true); }
-      it { expect(page).to have_selector ".video[poster*='/rails/active_storage/']" }
+      it { expect(page).to have_selector(".video[poster*='/rails/active_storage/']", wait: 30.seconds) }
     end
 
     context "when the sign video has been encoded" do

--- a/spec/system/edit_sign_feature_spec.rb
+++ b/spec/system/edit_sign_feature_spec.rb
@@ -146,7 +146,7 @@ RSpec.describe "Editing a sign", type: :system do
 
     context "when the sign video has had thumbnails generated" do
       it "displays the processed thumbnail" do
-        sign.update!(processed_thumbnails)
+        sign.update!(processed_thumbnails: true)
         visit sign_path(sign)
         expect(page).to have_selector(".video[poster*='/rails/active_storage/']")
       end

--- a/spec/system/edit_sign_feature_spec.rb
+++ b/spec/system/edit_sign_feature_spec.rb
@@ -145,8 +145,11 @@ RSpec.describe "Editing a sign", type: :system do
     end
 
     context "when the sign video has had thumbnails generated" do
-      before { sign.update!(processed_thumbnails: true); }
-      it { expect(page).to have_selector(".video[poster*='/rails/active_storage/']", wait: 30.seconds) }
+      it "displays the processed thumbnail" do
+        sign.update!(processed_thumbnails)
+        visit sign_path(sign)
+        expect(page).to have_selector(".video[poster*='/rails/active_storage/']")
+      end
     end
 
     context "when the sign video has been encoded" do

--- a/spec/system/sign_comments_spec.rb
+++ b/spec/system/sign_comments_spec.rb
@@ -131,6 +131,18 @@ RSpec.describe "Sign commenting" do
     end
   end
 
+  context "when the user is deleted" do
+    let!(:public_sign) { FactoryBot.create(:sign, :published) }
+    let!(:comment) { FactoryBot.create(:sign_comment, sign: public_sign, user: user) }
+
+    it "continues to show the comment, but not the user details" do
+      user.destroy!
+      visit sign_path(public_sign)
+      expect(page).to have_no_selector("sign-comments__comment__username--link")
+      expect(page).to have_selector ".sign-comments__comment", text: comment.comment
+    end
+  end
+
   context "pagination" do
     let!(:comments) { FactoryBot.create_list(:sign_comment, 30, sign: sign, user: user) }
 

--- a/spec/system/sign_comments_spec.rb
+++ b/spec/system/sign_comments_spec.rb
@@ -116,11 +116,12 @@ RSpec.describe "Sign commenting" do
   end
 
   context "removing", uses_javascript: true do
-    let!(:public_sign) { FactoryBot.create(:sign, :published) }
-    let!(:comment) { FactoryBot.create(:sign_comment, sign: public_sign, user: user) }
+    let(:commenter) { FactoryBot.create(:user) }
+    let!(:comment) { FactoryBot.create(:sign_comment, sign: sign, user: commenter) }
 
     it "approved user can delete own comment" do
-      visit sign_path(public_sign)
+      commenter.destroy!
+      visit sign_path(sign)
       within ".sign-comment__options" do
         click_on "Comment Options"
         accept_confirm do
@@ -132,12 +133,12 @@ RSpec.describe "Sign commenting" do
   end
 
   context "when the user is deleted" do
-    let!(:public_sign) { FactoryBot.create(:sign, :published) }
-    let!(:comment) { FactoryBot.create(:sign_comment, sign: public_sign, user: user) }
+    let(:commenter) { FactoryBot.create(:user) }
+    let!(:comment) { FactoryBot.create(:sign_comment, sign: sign, user: commenter) }
 
     it "continues to show the comment, but not the user details" do
-      user.destroy!
-      visit sign_path(public_sign)
+      commenter.destroy!
+      visit sign_path(sign)
       expect(page).to have_no_selector("sign-comments__comment__username--link")
       expect(page).to have_selector ".sign-comments__comment", text: comment.comment
     end

--- a/spec/system/sign_comments_spec.rb
+++ b/spec/system/sign_comments_spec.rb
@@ -115,11 +115,9 @@ RSpec.describe "Sign commenting" do
   end
 
   context "removing", uses_javascript: true do
-    let(:commenter) { FactoryBot.create(:user) }
-    let!(:comment) { FactoryBot.create(:sign_comment, sign: sign, user: commenter) }
+    let!(:comment) { FactoryBot.create(:sign_comment, sign: sign, user: user) }
 
     it "approved user can delete own comment" do
-      commenter.destroy!
       visit sign_path(sign)
       within ".sign-comment__options" do
         click_on "Comment Options"

--- a/spec/system/user_administration_spec.rb
+++ b/spec/system/user_administration_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "User administration", type: :system do
 
   before { visit_admin(:users, admin: admin) }
 
-  it_behaves_like "an Administrate dashboard", :users, except: %i[destroy new]
+  it_behaves_like "an Administrate dashboard", :users, except: %i[new]
 
   it "excludes unconfirmed users by default" do
     confirmed_user = FactoryBot.create(:user)


### PR DESCRIPTION
This pull request implements user deletion, including taking care of related records:

* Private folders can just be destroyed
* The existence of signs attached to the user should prevent destruction
* Shared folders which are owned by the user being destroyed should be reallocated to the next available collaborator (who is not also the user)
* Sign comments should remain, but should be displayed anonymously


https://user-images.githubusercontent.com/292020/208327049-33f3a7c5-2dfe-446a-88cf-c235e7bbbeb4.mp4

