### PR TITLE
NZSL-61: Display 'Other signs' in breadcrumbs for signs without topics, add to topics index page and other signs show page

### DIFF
--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -9,4 +9,12 @@ class TopicsController < ApplicationController
     @signs = policy_scope(@topic.signs)
     authorize @topic
   end
+
+  def uncategorised
+    @topic = Topic.new(name: Topic::NO_TOPIC_DESCRIPTION)
+    authorize @topic, :show?
+    @signs = policy_scope(Sign).uncategorised
+
+    render :show
+  end
 end

--- a/app/models/sign.rb
+++ b/app/models/sign.rb
@@ -47,6 +47,7 @@ class Sign < ApplicationRecord
   scope :preview, -> { limit(4) }
 
   scope :recent, -> { published.order(published_at: :desc) }
+  scope :uncategorised, -> { left_outer_joins(:sign_topics).group(:id).having("COUNT(sign_topics.id) = 0") }
 
   scope :for_cards, lambda {
     includes(:topics,

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -4,6 +4,8 @@ class Topic < ApplicationRecord
   has_many :sign_topics, dependent: :destroy
   has_many :signs, through: :sign_topics
 
+  NO_TOPIC_DESCRIPTION = "Other signs".freeze
+
   def featured
     featured_at.present?
   end

--- a/app/views/signs/show.html.erb
+++ b/app/views/signs/show.html.erb
@@ -9,6 +9,8 @@
     <li><%= link_to "Topics", "/topics" %></li>
     <% if @sign.topic.present? %>
       <li><%= link_to @sign.topic.name, "/topics/#{@sign.topic.to_param}" %></li>
+    <% else %>
+      <li><%= Topic::NO_TOPIC_DESCRIPTION %></li>
     <% end %>
     <li>
       <span class="show-for-sr">

--- a/app/views/topics/index.html.erb
+++ b/app/views/topics/index.html.erb
@@ -23,5 +23,8 @@
         <%= link_to content_tag(:p, topic.name, class: "royal"), topic, class: "no-underline" %>
       <% end %>
     </div>
+    <div class="list__section list__section--topics cell">
+      <%= link_to Topic::NO_TOPIC_DESCRIPTION, uncategorised_topics_path, class: "royal no-underline" %>
+    </div>
   </div>
 </div>

--- a/app/views/topics/show.html.erb
+++ b/app/views/topics/show.html.erb
@@ -15,7 +15,6 @@
     <h1><%= @topic.name %></h1>
     <div class="sign-grid cell">
       <% @signs.for_cards.each do |sign| %>
-        <% next unless sign.topics.include?(@topic) %>
         <%= render "signs/card", sign: sign %>
       <% end %>
     </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -54,7 +54,9 @@ Rails.application.routes.draw do
     end
   end
 
-  resources :topics, only: %i[index show]
+  resources :topics, only: %i[index show] do
+    get :uncategorised, on: :collection
+  end
 
   resources :folders do
     resources :share, only: %i[show create destroy], controller: :folder_share, param: :token

--- a/spec/models/sign_spec.rb
+++ b/spec/models/sign_spec.rb
@@ -207,4 +207,17 @@ RSpec.describe Sign, type: :model do
       expect(result).not_to include not_published
     end
   end
+
+  describe ".uncategorised" do
+    it "returns expected records" do
+      no_topic = FactoryBot.create(:sign)
+      no_topic.sign_topics.destroy_all
+      single_topic = FactoryBot.create(:sign)
+      multiple_topics = FactoryBot.create(:sign, topics: Topic.all.sample(2))
+
+      expect(described_class.uncategorised).to include no_topic
+      expect(described_class.uncategorised).not_to include single_topic
+      expect(described_class.uncategorised).not_to include multiple_topics
+    end
+  end
 end

--- a/spec/system/sign_show_page_spec.rb
+++ b/spec/system/sign_show_page_spec.rb
@@ -335,6 +335,12 @@ RSpec.describe "Sign show page", system: true do
     subject.breadcrumb { expect(subject).to have_content "Current: #{sign.word}" }
   end
 
+  it "shows a breadcrumb to 'Other signs' when there is no topic" do
+    sign.update!(topics: [])
+    visit current_path
+    subject.breadcrumb { expect(subject).to have_content Topic::NO_TOPIC_DESCRIPTION }
+  end
+
   it "shows a breadcrumb to the topic" do
     subject.breadcrumb { expect(subject).to have_link sign.topics.first.name }
   end

--- a/spec/system/topics_feature_spec.rb
+++ b/spec/system/topics_feature_spec.rb
@@ -33,14 +33,49 @@ RSpec.describe "Topics", type: :system do
 
     it { is_expected.to have_title "#{topic.name} – NZSL Share" }
     it { is_expected.to have_content topic.name }
+
     it "shows all published signs" do
       expect(topic.signs.count - 2).to eq topic.signs.published.count
       is_expected.to have_selector(".sign-card", count: topic.signs.published.count)
     end
+
     it "can click through to the sign card show page" do
       sign = topic.signs.first
       click_on sign.word
       expect(current_path).to eq sign_path(sign)
+    end
+  end
+
+  describe "uncategorised" do
+    it "can be navigated to" do
+      visit root_path
+      within(".hero-unit") { click_on("Browse Topics") }
+      click_on Topic::NO_TOPIC_DESCRIPTION
+      expect(page).to have_selector "h1", text: Topic::NO_TOPIC_DESCRIPTION
+    end
+
+    it "has the expected sign cards" do
+      uncategorised_private_sign = FactoryBot.create(:sign)
+      uncategorised_private_sign.sign_topics.destroy_all
+      uncategorised_published_sign = FactoryBot.create(:sign, :published)
+      uncategorised_published_sign.sign_topics.destroy_all
+
+      categorised_private_sign = FactoryBot.create(:sign, contributor:
+        uncategorised_private_sign.contributor)
+
+      auth = AuthenticateFeature.new(categorised_private_sign.contributor)
+      auth.sign_in
+
+      visit uncategorised_topics_path
+      expect(page).to have_selector(".sign-card#card_sign_#{uncategorised_published_sign.to_param}")
+      expect(page).to have_selector(".sign-card#card_sign_#{uncategorised_private_sign.to_param}")
+      expect(page).to have_no_selector(".sign-card#card_sign_#{categorised_private_sign.to_param}")
+
+      auth.sign_out
+      visit uncategorised_topics_path
+      expect(page).to have_selector(".sign-card#card_sign_#{uncategorised_published_sign.to_param}")
+      expect(page).to have_no_selector(".sign-card#card_sign_#{uncategorised_private_sign.to_param}")
+      expect(page).to have_no_selector(".sign-card#card_sign_#{categorised_private_sign.to_param}")
     end
   end
 end

--- a/spec/system/topics_feature_spec.rb
+++ b/spec/system/topics_feature_spec.rb
@@ -63,15 +63,14 @@ RSpec.describe "Topics", type: :system do
       categorised_private_sign = FactoryBot.create(:sign, contributor:
         uncategorised_private_sign.contributor)
 
-      auth = AuthenticateFeature.new(categorised_private_sign.contributor)
-      auth.sign_in
+      sign_in categorised_private_sign.contributor
 
       visit uncategorised_topics_path
       expect(page).to have_selector(".sign-card#card_sign_#{uncategorised_published_sign.to_param}")
       expect(page).to have_selector(".sign-card#card_sign_#{uncategorised_private_sign.to_param}")
       expect(page).to have_no_selector(".sign-card#card_sign_#{categorised_private_sign.to_param}")
 
-      auth.sign_out
+      sign_out :user
       visit uncategorised_topics_path
       expect(page).to have_selector(".sign-card#card_sign_#{uncategorised_published_sign.to_param}")
       expect(page).to have_no_selector(".sign-card#card_sign_#{uncategorised_private_sign.to_param}")

--- a/spec/system/topics_feature_spec.rb
+++ b/spec/system/topics_feature_spec.rb
@@ -17,6 +17,10 @@ RSpec.describe "Topics", type: :system do
     it "has a link to view all signs" do
       expect(page).to have_link "See all signs", href: public_signs_path
     end
+
+    it "has a link to view uncategorised signs" do
+      expect(page).to have_link Topic::NO_TOPIC_DESCRIPTION, href: uncategorised_topics_path
+    end
   end
 
   describe "show" do


### PR DESCRIPTION
This pull request wraps up NZSL-61:

* Adds a breadcrumb to signs without a topic, called 'Other signs'. This cannot be clicked on, but indicates that the sign doesn't have a topic. 
![image](https://user-images.githubusercontent.com/292020/208536896-7c2caf3e-612a-4f23-9657-d291374f7d23.png)
* Adds a link to the bottom of the topics list page - 'Other signs'
![image](https://user-images.githubusercontent.com/292020/208536950-6357c208-3cd8-4749-90ba-4936ef4c2a4f.png)
* Adds a 'uncategorised' action to topics controller to display any signs accessible to the signed-in user which don't have topics 
![image](https://user-images.githubusercontent.com/292020/208537042-7918aa62-3830-4639-8a40-73d3b27fce7c.png)
