### PR TITLE
Update the dictionary if it is older than 1 month old when the application starts

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,3 @@
-web:     bundle exec rake dictionary:update && bundle exec puma -C config/puma.rb
-worker:  bundle exec rake dictionary:update && bundle exec sidekiq -C config/sidekiq.yml
+web:     bundle exec puma -C config/puma.rb
+worker:  bundle exec sidekiq -C config/sidekiq.yml
 release: bundle exec rake dictionary:update && bundle exec rake db:migrate db:seed

--- a/README.md
+++ b/README.md
@@ -36,14 +36,21 @@ If you know what you're doing already, `bin/setup` should get you set up, and yo
 
 ## Signbank Dictionary
 
-This application allows users to search for signs that are already published in the
-[NZSL Dictionary](https://nzsl.nz). This reduces the risk that a contribution duplicates already-published work.
+This application allows users to search for signs that are already published in
+the [NZSL Dictionary](https://nzsl.nz). This reduces the risk that a
+contribution duplicates already-published work.
 
-The dictionary data is consumed from a SQLite database that is downloaded from a Github release. From time to time, the dictionary data is updated, and exported by [nzsl-dictionary-scripts](https://github.com/odnzsl/nzsl-dictionary-scripts).
+The dictionary data is consumed from a SQLite database that is downloaded from a
+Github release. From time to time, the dictionary data is updated, and exported
+by [nzsl-dictionary-scripts](https://github.com/odnzsl/nzsl-dictionary-scripts).
 
-Unless there has been a major change to published data, **you don't need to update the dictionary SQLite file often**. Running `bin/setup` fetched the most recent copy for you during application setup. Additionally, when the application is started after each deploy, the most recent copy is also downloaded in staging and production.
+Unless there has been a major change to published data, **you don't need to
+update the dictionary SQLite file often**. When the application is started, the
+most recent copy is also downloaded if the database file is missing or older
+than 1 month.
 
-If you know there has been an update, and want the latest copy, you can run `bundle exec rake dictionary:update` to download it.
+If you know there has been an update, and want the latest copy immediately, you
+can run `bundle exec rake dictionary:update` to download it.
 
 ## Deployment
 

--- a/bin/setup
+++ b/bin/setup
@@ -11,7 +11,6 @@ def setup!
     copy "config/database.example.yml"
     copy "config/secrets.example.yml"
     test_local_env_contains_required_keys
-    run  "bin/rake dictionary:update"
     run  "bin/rake tmp:create"
     run  "bin/rake db:create:all"
     run  "bin/rake db:migrate"

--- a/config/initializers/dictionary_sign.rb
+++ b/config/initializers/dictionary_sign.rb
@@ -5,6 +5,12 @@ Rails.application.reloader.to_prepare do
   dictionary_mode = ENV["DICTIONARY_MODE"]&.downcase
   dictionary_sign_model = dictionary_mode == "freelex" ? FreelexSign : DictionarySign
   Rails.application.config.dictionary_sign_model = dictionary_sign_model
+  break if dictionary_sign_model != DictionarySign
+
+  # Update the dictionary file if it is older than 1 month
+  path = Rails.root.join("db/nzsl-dictionary.db.sqlite3")
+  Rails.application.load_tasks
+  Rake::Task["dictionary:update"].execute if !path.exist? || path.mtime <= 1.month.ago
 
   ##
   # All other tables make heavy use of a 'word' column. Add an alias for it here so that


### PR DESCRIPTION
This is more resilient than trying to intercept all process invocations. On
heroku, the deploy failed due to assets:precompile being run for example.

Instead, we can download the database each time the app starts, to make sure we
are using the most up-to-date version. Heroku will always update the most recent
version, since the database is gitignored so not present in the slug.