### PR TITLE
ci: attempt to check rate limiting headers in the case of a error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,11 @@ jobs:
       - name: Check dependencies for security vulnerabilities
         uses: g-rath/check-with-osv-detector@v0.1.0
 
+      # if we're failed, make a cURL request to the GH API so we can
+      # check if we're being rate limited via the response headers
+      - if: ${{ failure() }}
+        run: curl -I https://api.github.com/users/octocat
+
   rubocop:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
This is a bit weird, but @joshmcarthur has been having some GH API related failures for both the `check-with-osv-detector` action and with tests (as they download the sign db using the same method) - we suspect it's because of rate limiting, which we can check by inspecting the headers of a request made to the GH API (which is what this change has CI does when it fails)