### PR TITLE
NZSL-95, NZSL-96: SignCommentActivity model and tracking API

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -41,6 +41,7 @@ Metrics/BlockLength:
     - "lib/tasks/**/*"
 
 Metrics/ClassLength:
+  Max: 120
   Exclude:
     - "spec/**/*"
 

--- a/app/controllers/sign_comments_controller.rb
+++ b/app/controllers/sign_comments_controller.rb
@@ -33,7 +33,8 @@ class SignCommentsController < ApplicationController
     @sign = fetch_sign
     @sign_comment = fetch_sign_comment
     authorize @sign_comment
-    SignComment.remove(@sign_comment)
+    @sign_comment.remove
+
     if request.referer.include?("admin/comment_reports")
       respond_to do |format|
         format.js { render js: "window.location.href = '#{admin_comment_reports_path}'" }

--- a/app/models/sign_comment.rb
+++ b/app/models/sign_comment.rb
@@ -38,10 +38,9 @@ class SignComment < ApplicationRecord
     video.blob.metadata[:description] || ""
   end
 
-  def self.remove(sign_comment)
-    ActiveRecord::Base.transaction do
-      sign_comment.update!(removed: true)
-      sign_comment.reports.destroy_all
-    end
+
+  def remove
+    update!(removed: true)
+    reports.destroy_all
   end
 end

--- a/app/models/sign_comment_activity.rb
+++ b/app/models/sign_comment_activity.rb
@@ -1,0 +1,5 @@
+class SignCommentActivity < ApplicationRecord
+  belongs_to :sign_comment
+  belongs_to :user
+  enum key: { read: "read" }
+end

--- a/db/migrate/20221221033513_create_sign_comment_activities.rb
+++ b/db/migrate/20221221033513_create_sign_comment_activities.rb
@@ -1,0 +1,13 @@
+class CreateSignCommentActivities < ActiveRecord::Migration[6.1]
+  def change
+    create_table :sign_comment_activities do |t|
+      t.belongs_to :sign_comment, null: false, foreign_key: true
+      t.belongs_to :user, null: false, foreign_key: true
+      t.string :key, null: false, index: true
+
+      t.timestamps
+    end
+
+    add_index :sign_comment_activities, %i[sign_comment_id user_id key], name: :idx_sign_comment_activities
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_11_28_080318) do
+ActiveRecord::Schema.define(version: 2022_12_21_033513) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -132,10 +132,22 @@ ActiveRecord::Schema.define(version: 2021_11_28_080318) do
     t.index ["user_id"], name: "index_sign_activities_on_user_id"
   end
 
+  create_table "sign_comment_activities", force: :cascade do |t|
+    t.bigint "sign_comment_id", null: false
+    t.bigint "user_id", null: false
+    t.string "key", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["key"], name: "index_sign_comment_activities_on_key"
+    t.index ["sign_comment_id", "user_id", "key"], name: "idx_sign_comment_activities"
+    t.index ["sign_comment_id"], name: "index_sign_comment_activities_on_sign_comment_id"
+    t.index ["user_id"], name: "index_sign_comment_activities_on_user_id"
+  end
+
   create_table "sign_comments", force: :cascade do |t|
     t.bigint "parent_id"
     t.bigint "sign_id", null: false
-    t.bigint "user_id", null: false
+    t.bigint "user_id"
     t.text "comment"
     t.text "sign_status", null: false
     t.boolean "display", default: true
@@ -250,6 +262,8 @@ ActiveRecord::Schema.define(version: 2021_11_28_080318) do
   add_foreign_key "folder_memberships", "signs"
   add_foreign_key "sign_activities", "signs"
   add_foreign_key "sign_activities", "users"
+  add_foreign_key "sign_comment_activities", "sign_comments"
+  add_foreign_key "sign_comment_activities", "users"
   add_foreign_key "sign_comments", "signs"
   add_foreign_key "sign_comments", "users"
   add_foreign_key "sign_topics", "signs"

--- a/lib/tasks/dictionary.rake
+++ b/lib/tasks/dictionary.rake
@@ -5,7 +5,16 @@ namespace :dictionary do
     filename = "nzsl.db"
     content_type = "application/vnd.sqlite3"
     release_uri = URI::HTTPS.build(host: "api.github.com", path: "/repos/#{repo}/releases/latest")
-    release = JSON.parse(release_uri.open.read)
+    release = {}
+
+    begin
+      release = JSON.parse(release_uri.open.read)
+    rescue OpenURI::HTTPError => e
+      puts "Failed to access release, retrying after 10s... (#{e})"
+      sleep 10
+      retry
+    end
+
     database_asset = release["assets"].find do |asset|
       asset["name"] == filename && asset["content_type"] == content_type
     end

--- a/spec/factories/sign_comment_activities.rb
+++ b/spec/factories/sign_comment_activities.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :sign_comment_activity do
+    sign_comment
+    user
+    key { :read }
+  end
+end

--- a/spec/models/sign_comment_activity_spec.rb
+++ b/spec/models/sign_comment_activity_spec.rb
@@ -1,0 +1,13 @@
+require "rails_helper"
+
+RSpec.describe SignCommentActivity, type: :model do
+  subject(:model) { FactoryBot.build(:sign_comment_activity) }
+
+  it "belongs to a user" do
+    expect(model.user).to be_a User
+  end
+
+  it "belongs to a sign comment" do
+    expect(model.sign_comment).to be_a SignComment
+  end
+end

--- a/spec/models/sign_comment_spec.rb
+++ b/spec/models/sign_comment_spec.rb
@@ -15,4 +15,35 @@ RSpec.describe SignComment, type: :model do
     it { is_expected.to be_valid }
     it { expect(model.folder).to be_a Folder }
   end
+
+  describe ".read_by?" do
+    let(:model) { FactoryBot.create(:sign_comment) }
+    let(:user) { FactoryBot.create(:user) }
+
+    subject { model.read_by?(user) }
+
+    context "the user has read the comment" do
+      before { model.read_by!(user) }
+      it { is_expected.to eq true }
+    end
+
+    context "the user has not read the comment" do
+      it { is_expected.to eq false }
+    end
+  end
+
+  describe ".read_by!" do
+    let(:model) { FactoryBot.create(:sign_comment) }
+    let(:user) { FactoryBot.create(:user) }
+
+    subject { model.read_by!(user) }
+
+    it { expect { subject }.to change { SignCommentActivity.count }.by(1) }
+    it { expect { subject }.to change { model.read_by?(user) }.from(false).to(true) }
+
+    context "already read" do
+      before { model.read_by!(user) }
+      it { expect { subject }.not_to change(SignActivity, :count) }
+    end
+  end
 end

--- a/spec/requests/sign_spec.rb
+++ b/spec/requests/sign_spec.rb
@@ -4,25 +4,41 @@ require "rails_helper"
 
 RSpec.describe "sign", type: :request do
   let(:user) { FactoryBot.create(:user, :approved) }
-  let(:sign) { FactoryBot.create(:sign, :published) }
+  let(:sign) { FactoryBot.create(:sign, :published, contributor: user) }
 
-  let(:update) do
-    ->(sign) { patch "/signs/#{sign.id}", params: { sign: { notes: "this is a note for a sign" } } }
-  end
+  before { sign_in user }
 
-  describe "controller actions" do
-    before(:each) do
-      sign_in user
-      sign.contributor = user
-      sign.save
+  describe "PATCH /:id" do
+    let(:update) do
+      ->(sign) { patch "/signs/#{sign.id}", params: { sign: { notes: "this is a note for a sign" } } }
     end
 
-    describe "update" do
-      it "does not change sign ownership after update" do
-        expect(sign.contributor).to eq user
-        update.call(sign)
-        expect(sign.contributor).to eq user
+    it "does not change sign ownership after update" do
+      expect(sign.contributor).to eq user
+      update.call(sign)
+      expect(sign.contributor).to eq user
+    end
+  end
+
+  describe "GET show" do
+    it "marks unseen comments as read" do
+      read = FactoryBot.create_list(:sign_comment, 5, sign: sign).each do |comment|
+        comment.read_by!(user)
       end
+
+      unread = FactoryBot.create_list(:sign_comment, 5, sign: sign)
+
+      expect { get sign_path(sign) }.to change(SignCommentActivity.read, :count).by(unread.count)
+      expect(read.map { |r| r.read_by?(user) }.all?).to be true
+      expect(unread.map { |r| r.read_by?(user) }.all?).to be true
+    end
+
+    it "only marks one page of comments as read at a time" do
+      # Page size of 10
+      FactoryBot.create_list(:sign_comment, 15, sign: sign)
+      expect { get sign_path(sign) }.to change(SignCommentActivity.read, :count).by(10)
+      expect { get sign_path(sign) }.to change(SignCommentActivity.read, :count).by(0)
+      expect { get sign_path(sign, comments_page: 2) }.to change(SignCommentActivity.read, :count).by(5)
     end
   end
 end


### PR DESCRIPTION
This pull request implements the data structure and API to track views on sign comments. This API is called from `SignsController#show` as each page of comments is read. 

At this stage, this data is not used anywhere, however upcoming tasks will use the data to determine whether to indicate that there are unread signs on a comment.
