### PR TITLE
NZSL-61: Fixes for uncategorised topic signs

### DIFF
--- a/app/policies/sign_policy.rb
+++ b/app/policies/sign_policy.rb
@@ -119,7 +119,7 @@ class SignPolicy < ApplicationPolicy
               .pluck("folder_memberships.sign_id")
 
         ids = (collaboration_sign_ids + resolve_moderator.map(&:id)).uniq
-        Sign.where(id: ids)
+        scope.where(id: ids)
       elsif user
         resolve_user
       else

--- a/app/views/signs/show.html.erb
+++ b/app/views/signs/show.html.erb
@@ -9,6 +9,8 @@
     <li><%= link_to "Topics", "/topics" %></li>
     <% if @sign.topic.present? %>
       <li><%= link_to @sign.topic.name, "/topics/#{@sign.topic.to_param}" %></li>
+    <% elsif @sign.topics.any? %>
+      <li><%= link_to @sign.topics.first.name, "/topics/#{@sign.topics.first.to_param}" %></li>
     <% else %>
       <li><%= Topic::NO_TOPIC_DESCRIPTION %></li>
     <% end %>

--- a/spec/policies/sign_policy_spec.rb
+++ b/spec/policies/sign_policy_spec.rb
@@ -29,6 +29,13 @@ RSpec.describe SignPolicy do
           expect(scope.map(&:status).uniq).to eq ["personal"]
         end
 
+        it "applies any existing clauses on the scope" do
+          signs = FactoryBot.create_list(:sign, 3, :personal, contributor: user)
+          scope = Pundit.policy_scope!(user, Sign.where(id: signs.last))
+          expect(scope.count).to eq 1
+          expect(scope.first).to eq signs.last
+        end
+
         it "does not have scope for other users private signs" do
           FactoryBot.create_list(:sign, 3, :personal)
           scope = Pundit.policy_scope!(user, Sign)

--- a/spec/system/sign_show_page_spec.rb
+++ b/spec/system/sign_show_page_spec.rb
@@ -355,8 +355,26 @@ RSpec.describe "Sign show page", system: true do
     subject.breadcrumb { expect(subject).to have_content Topic::NO_TOPIC_DESCRIPTION }
   end
 
-  it "shows a breadcrumb to the topic" do
+  it "shows a breadcrumb to the first topic when there are multiple topics" do
+    sign.topics << FactoryBot.create(:topic)
     subject.breadcrumb { expect(subject).to have_link sign.topics.first.name }
+  end
+
+  it "shows a breadcrumb to the referring topic if resolved" do
+    first_topic = FactoryBot.create(:topic)
+    second_topic = FactoryBot.create(:topic)
+    sign.topics = [first_topic, second_topic]
+
+    visit current_path
+    subject.breadcrumb { expect(subject).to have_link first_topic.name }
+
+    visit topic_path(first_topic)
+    click_on sign.word
+    subject.breadcrumb { expect(subject).to have_content first_topic.name }
+
+    visit topic_path(second_topic)
+    click_on sign.word
+    subject.breadcrumb { expect(subject).to have_content second_topic.name }
   end
 
   it "displays the sign notes" do


### PR DESCRIPTION
This PR fixes two issues Micky found in UAT:

* `SignPolicy::Scope` wasn't retaining existing where clauses on the scope passed to it, but was resetting the scope. This meant that when a moderator was signed in, viewing any topic would show all the signs they could access, not just the signs in that topic.
* The way we choose a topic to show in the breadcrumbs is...more complex than I thought. Basically if you have arrived on the sign page from a topic, we show that topic name as the breadcrumb. Otherwise we show the first topic that belongs to the sign. The fix for this was to fall back so that if the sign cannot resolve a topic from the referrer, it will use the first topic in the collection. In practical terms, this issue _mostly_ happened because of the above issue - normally, if your referrer matches the topic regexp, we can have a reasonable expectation to resolve the correct topic. Because the topic page was showing all signs, including those not in that topic, the referer would match a topic page when that topic was not actually assigned to that sign.

I've tested both of these fixes also.