### PR TITLE
NZSL-95: Destroy sign comment activity belonging to the user when the user is destroyed

### DIFF
--- a/app/models/sign_comment.rb
+++ b/app/models/sign_comment.rb
@@ -62,6 +62,7 @@ class SignComment < ApplicationRecord
 
   def remove
     update!(removed: true)
+    activities.destroy_all
     reports.destroy_all
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -18,6 +18,7 @@ class User < ApplicationRecord
   has_many :collaborations, foreign_key: :collaborator_id, inverse_of: :collaborator, dependent: :destroy
 
   has_many :sign_comments, dependent: :nullify
+  has_many :sign_comment_activities, dependent: :destroy
 
   has_one :approved_user_application, dependent: :destroy
   has_one_attached :avatar


### PR DESCRIPTION
Two features collided. I added `SignCommentActivity`, which has a foreign key against `users`, which is violated when we attempt to destroy the user (NZSL-59). 

This is fixed by adding `dependent: : destroy` in the user model to make sure we delete any sign comment activities when we destroy a user. I also fixed a similar issue when removing a comment, where we should also remove any activity on the sign comment (if a comment is un-removed, this should count as a new comment)