### PR TITLE
Only record sign comment activity if a user is signed in

### DIFF
--- a/app/controllers/signs_controller.rb
+++ b/app/controllers/signs_controller.rb
@@ -128,6 +128,8 @@ class SignsController < ApplicationController
   end
 
   def mark_comments_as_read
+    return unless user_signed_in?
+
     @comments.each { |c| c.read_by!(current_user) }
   end
 end

--- a/spec/requests/sign_spec.rb
+++ b/spec/requests/sign_spec.rb
@@ -40,5 +40,11 @@ RSpec.describe "sign", type: :request do
       expect { get sign_path(sign) }.to change(SignCommentActivity.read, :count).by(0)
       expect { get sign_path(sign, comments_page: 2) }.to change(SignCommentActivity.read, :count).by(5)
     end
+
+    it "doesn't mark comments as read when there is no user signed in" do
+      sign_out :user
+      FactoryBot.create(:sign_comment, sign: sign)
+      expect { get sign_path(sign) }.not_to change(SignCommentActivity.read, :count)
+    end
   end
 end


### PR DESCRIPTION
This is really bad QA on my part :-/

If the user is not logged in, we shouldn't try and record sign comment activity, since obviously we need a user attached to this activity for it to be useful. Added a guard clause, and a test to assert that when the user is not signed in, it doesn't break the request, and doesn't record any activity.