### PR TITLE
ci: use a specific version of `osv-detector` to avoid GH rate limiting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,12 +20,9 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Check dependencies for security vulnerabilities
-        uses: g-rath/check-with-osv-detector@v0.1.0
-
-      # if we're failed, make a cURL request to the GH API so we can
-      # check if we're being rate limited via the response headers
-      - if: ${{ failure() }}
-        run: curl -I https://api.github.com/users/octocat
+        uses: g-rath/check-with-osv-detector@v0.1.1
+        with:
+          osv-detector-version: 0.9.1
 
   rubocop:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Turns out that unauthenticated GH API requests are limited to 60 _per hour_ (I thought it was per minute) - the action only needs to talk to the GH API to figure out what the latest version of the detector is, so we can just provide a specific version instead.

The detector is pretty stable, so there shouldn't be any strong downside to this.