### PR TITLE
ci: update `osv-detector` action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,9 +20,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Check dependencies for security vulnerabilities
-        uses: g-rath/check-with-osv-detector@v0.1.1
-        with:
-          osv-detector-version: 0.9.1
+        uses: g-rath/check-with-osv-detector@6bf2c012dff284895d644e970294396b01aecc1c
 
   rubocop:
     runs-on: ubuntu-latest


### PR DESCRIPTION
~See https://github.com/G-Rath/check-with-osv-detector/pull/2~

~If this works, I'll publish as v0.2.0 and then change this PR over to using that instead of a commit.~

This should hopefully allow us to not specify a specific version