### PR TITLE
NZSL-68: Add a feature flag to use legacy or uppy file uploads

### DIFF
--- a/app/views/signs/new.html.erb
+++ b/app/views/signs/new.html.erb
@@ -12,11 +12,15 @@
   <div class="cell grid-x padding-2">
     <%= render "errors" %>
     <%= form_with model: @sign, class: "cell", id: "new_sign" do |f| %>
-      <div class="file-upload" data-file-upload-controller="sign[video]">
-        <%= f.label :video, "Browse files", class: "button primary large" %>
-        <%= f.file_field :video, class: "show-for-sr" %>
-        <%= f.submit "Start Upload", class: "button secondary large" %>
-      </div>
+      <% if Rails.application.config.upload_mode == :uppy %>
+        <div data-controller="file-upload"></div>
+      <% else %>
+        <div class="file-upload" data-file-upload-controller="sign[video]">
+          <%= f.label :video, "Browse files", class: "button primary large" %>
+          <%= f.file_field :video, class: "show-for-sr" %>
+          <%= f.submit "Start Upload", class: "button secondary large" %>
+        </div>
+      <% end %>
     <% end %>
 
     <div class="cell padding-top-1 padding-bottom-1">

--- a/config/application.rb
+++ b/config/application.rb
@@ -31,5 +31,11 @@ module NzslShare
 
     config.contact_email = ENV.fetch("CONTACT_EMAIL", ENV.fetch("MAIL_FROM", nil))
     config.google_analytics_container_id = ENV.fetch("GOOGLE_ANALYTICS_CONTAINER_ID", nil)
+
+    config.upload_mode = if ENV.fetch("FEATURE_MULTIPLE_UPLOAD", "false").match?(/\Atrue|y/)
+                           :uppy
+                         else
+                           :legacy
+                         end
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -74,6 +74,12 @@ RSpec.configure do |config|
     driven_by :chrome
   end
 
+  # Allow tests to specify a particular upload mode (uppy or legacy).
+  config.before(:each, :upload_mode) do |example|
+    allow(Rails.application.config).to receive(:upload_mode)
+      .and_return(example.metadata.fetch(:upload_mode))
+  end
+
   # RSpec Rails can automatically mix in different behaviours to your tests
   # based on their file location, for example enabling you to call `get` and
   # `post` in specs under `spec/controllers`.

--- a/spec/system/contribute_sign_feature_spec.rb
+++ b/spec/system/contribute_sign_feature_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "Contributing a new sign", type: :system do
+RSpec.describe "Contributing a new sign", type: :system, upload_mode: :legacy do
   let(:user) { FactoryBot.create(:user) }
   subject { ContributeSignFeature.new }
   before do

--- a/spec/views/signs/new.html.erb_spec.rb
+++ b/spec/views/signs/new.html.erb_spec.rb
@@ -1,0 +1,18 @@
+require "rails_helper"
+
+RSpec.describe "signs/new.html.erb", type: :view do
+  let(:sign) { Sign.new }
+
+  before do
+    assign(:sign, sign)
+    render
+  end
+
+  it "shows the file upload area", upload_mode: :legacy do
+    expect(rendered).to have_selector(".file-upload[data-file-upload-controller='sign[video]']")
+  end
+
+  it "shows the multiple file upload area", upload_mode: :uppy do
+    expect(rendered).to have_selector("[data-controller='file-upload']")
+  end
+end


### PR DESCRIPTION
This pull request implements a feature flag to allow us to select whether to use the Uppy file upload, or the older, "Legacy" file upload. I'm introducing this feature flag so that I can release iterations on the uppy implementation onto `main` rather than accruing a large changeset. This allows us to quickly flip the app into using one implementation or the other until we are ready to switch over, at which point we can remove the feature flag.

I'm expecting most of the Uppy code to be in JS for now, so the if condition just wraps a div using Stimulus-style controller attributes. 