### PR TITLE
Must use 'next' instead of 'break' to guard within proc closure

### DIFF
--- a/config/initializers/dictionary_sign.rb
+++ b/config/initializers/dictionary_sign.rb
@@ -5,7 +5,7 @@ Rails.application.reloader.to_prepare do
   dictionary_mode = ENV["DICTIONARY_MODE"]&.downcase
   dictionary_sign_model = dictionary_mode == "freelex" ? FreelexSign : DictionarySign
   Rails.application.config.dictionary_sign_model = dictionary_sign_model
-  break if dictionary_sign_model != DictionarySign
+  next if dictionary_sign_model != DictionarySign
 
   # Update the dictionary file if it is older than 1 month
   path = Rails.root.join("db/nzsl-dictionary.db.sqlite3")


### PR DESCRIPTION
Fixes a failed production build that we picked up specifically because we want to run production in Freelex mode for now, so we hadn't run this code path since refactoring to use `to_prepare`. 

Switching to `next` allows the guard clause to work correctly.