### PR TITLE
NZSL-109: Add file size, contribution limit and type restrictions to Uppy for creating signs

### DIFF
--- a/app/frontend/components/create-sign-form.js
+++ b/app/frontend/components/create-sign-form.js
@@ -1,2 +1,26 @@
 import Rails from "@rails/ujs";
+import uppyFileUpload from "./uppy-file-upload";
 $(document).on("upload-success", "#new_sign .file-upload", () => Rails.fire($("#new_sign").get(0), "submit"));
+
+const maxFileSizeMb = 250;
+
+const createSignController = (container) => {
+  const uppy = uppyFileUpload(container);
+  const maxNumberOfFiles = container.dataset.createSignContributionLimitValue;
+
+  if (!maxNumberOfFiles) {
+    throw "Required option missing: contributionLimitValue";
+  }
+
+
+  uppy.setOptions({
+    restrictions: {
+      maxFileSize: (maxFileSizeMb * 1024) * 1024,  // 250 mb
+      maxNumberOfFiles: maxNumberOfFiles,
+      minNumberOfFiles: 1,
+      allowedFileTypes: ["video/*", "application/mp4"]
+    }
+  });
+};
+
+$(() => { $("[data-controller='create-sign']").each((_idx, container) => createSignController(container)); });

--- a/app/frontend/components/create-sign-form.js
+++ b/app/frontend/components/create-sign-form.js
@@ -15,7 +15,7 @@ const createSignController = (container) => {
 
   uppy.setOptions({
     restrictions: {
-      maxFileSize: (maxFileSizeMb * 1024) * 1024,  // 250 mb
+      maxFileSize: (maxFileSizeMb * 1024) * 1024,
       maxNumberOfFiles: maxNumberOfFiles,
       minNumberOfFiles: 1,
       allowedFileTypes: ["video/*", "application/mp4"]

--- a/app/frontend/components/uppy-file-upload.js
+++ b/app/frontend/components/uppy-file-upload.js
@@ -10,7 +10,6 @@ const uppyFileUpload = (container) => {
     id: container.id
   });
 
-
   uppy.use(DropTarget, { target: document.body });
   uppy.use(Webcam,  { modes: "video-only", countdown: true });
   uppy.use(ActiveStorageUpload, { directUploadUrl: "/rails/active_storage/direct_uploads" });
@@ -21,7 +20,10 @@ const uppyFileUpload = (container) => {
     proudlyDisplayPoweredByUppy: false,
     plugins: ["Webcam"]
   });
+
+  return uppy;
 };
 
+export default uppyFileUpload;
 
 $(() => $("[data-controller='file-upload']").each((_idx, container) => uppyFileUpload(container)));

--- a/app/views/signs/new.html.erb
+++ b/app/views/signs/new.html.erb
@@ -13,7 +13,9 @@
     <%= render "errors" %>
     <%= form_with model: @sign, class: "cell", id: "new_sign" do |f| %>
       <% if Rails.application.config.upload_mode == :uppy %>
-        <div data-controller="file-upload"></div>
+        <div data-controller="create-sign"
+             data-create-sign-contribution-limit-value="<%= current_user.contribution_limit - current_user.signs.count %>"
+        ></div>
       <% else %>
         <div class="file-upload" data-file-upload-controller="sign[video]">
           <%= f.label :video, "Browse files", class: "button primary large" %>

--- a/spec/views/signs/new.html.erb_spec.rb
+++ b/spec/views/signs/new.html.erb_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe "signs/new.html.erb", type: :view do
 
   before do
     assign(:sign, sign)
+    allow(view).to receive(:current_user).and_return(User.new)
     render
   end
 
@@ -13,6 +14,13 @@ RSpec.describe "signs/new.html.erb", type: :view do
   end
 
   it "shows the multiple file upload area", upload_mode: :uppy do
-    expect(rendered).to have_selector("[data-controller='file-upload']")
+    expect(rendered).to have_selector("[data-controller='create-sign']")
+  end
+
+  it "passes the contribution limit to the create sign process", upload_mode: :uppy do
+    view.current_user.contribution_limit = 10
+    allow(view.current_user.signs).to receive(:count).and_return(5)
+    rendered = render
+    expect(rendered).to have_selector("[data-create-sign-contribution-limit-value='5']")
   end
 end


### PR DESCRIPTION
Wraps the file upload controller with a new controller with specific rules for sign videos. We'll need to implement one of these for each 'type' of upload (video comments, examples, editing sign video), just to handle the workflow each time. 

This new controller at this stage just enforces sign video rules - file size, type, and contribution limits. 

File size restriction:


https://user-images.githubusercontent.com/292020/214430431-f6227564-556c-40a9-8fd0-54d6cf481e9e.mp4

File type restriction:


https://user-images.githubusercontent.com/292020/214430535-9a9ff419-ab20-46ba-a375-8d85e346e441.mp4

Contribution limit restriction:


https://user-images.githubusercontent.com/292020/214430593-d41543c1-b417-4f16-88a9-435a90163ffa.mp4



