### PR TITLE
NZSL-57: UAT feedback

### DIFF
--- a/app/controllers/signs_controller.rb
+++ b/app/controllers/signs_controller.rb
@@ -130,6 +130,13 @@ class SignsController < ApplicationController # rubocop:disable Metrics/ClassLen
   def mark_comments_as_read
     return unless user_signed_in?
 
-    @comments.each { |c| c.read_by!(current_user) }
+    @comments.each { |comment| mark_comment_as_read(comment) }
+  end
+
+  ## Recursively marks each comment and it's replies (etc)
+  # as read.
+  def mark_comment_as_read(comment)
+    comment.read_by!(current_user)
+    comment.replies.each { |reply| mark_comment_as_read(reply) }
   end
 end

--- a/app/frontend/components/_sign-card.scss
+++ b/app/frontend/components/_sign-card.scss
@@ -269,7 +269,7 @@
     &--comments--unread {
       position: relative;
       &::after {
-        background: get-color(royal);
+        background: get-color(accent);
         border-radius: 50px;
         border: solid 1px get-color(white);
         content: " ";

--- a/app/policies/sign_comment_policy.rb
+++ b/app/policies/sign_comment_policy.rb
@@ -65,7 +65,7 @@ class SignCommentPolicy < ApplicationPolicy
 
   class Scope < Scope
     def resolve
-      accessible_signs = SignPolicy::Scope.new(user, Sign.where(id: scope.pluck(:sign_id))).resolve
+      accessible_signs = SignPolicy::Scope.new(user, Sign).resolve
       folder_ids = accessible_signs.left_outer_joins(:folders).pluck("folders.id").compact
       accessible_folders = FolderPolicy::Scope.new(user, Folder.where(id: folder_ids)).resolve
 

--- a/app/policies/sign_comment_policy.rb
+++ b/app/policies/sign_comment_policy.rb
@@ -65,8 +65,9 @@ class SignCommentPolicy < ApplicationPolicy
 
   class Scope < Scope
     def resolve
-      accessible_signs = SignPolicy::Scope.new(user, Sign).resolve
-      accessible_folders = FolderPolicy::Scope.new(user, Folder).resolve
+      accessible_signs = SignPolicy::Scope.new(user, Sign.where(id: scope.pluck(:sign_id))).resolve
+      folder_ids = accessible_signs.left_outer_joins(:folders).pluck("folders.id").compact
+      accessible_folders = FolderPolicy::Scope.new(user, Folder.where(id: folder_ids)).resolve
 
       scope
         .where(sign_id: accessible_signs)

--- a/spec/policies/sign_comment_policy_spec.rb
+++ b/spec/policies/sign_comment_policy_spec.rb
@@ -25,9 +25,16 @@ RSpec.describe SignCommentPolicy, type: :policy do
       expect(resolve(user)).not_to include comment
     end
 
+    it "does not resolve a folder comment on a private sign when the sign no longer belongs to the folder" do
+      folder = FactoryBot.create(:folder)
+      sign = FactoryBot.create(:sign, contributor: folder.user)
+      comment = FactoryBot.create(:sign_comment, folder: folder, sign: sign)
+      expect(resolve(folder.user)).not_to include comment
+    end
+
     it "resolves a folder comment on a private sign" do
       folder = FactoryBot.create(:folder)
-      folder.signs << sign = FactoryBot.create(:sign)
+      folder.signs << sign = FactoryBot.create(:sign, contributor: folder.user)
       comment = FactoryBot.create(:sign_comment, folder: folder, sign: sign)
       expect(resolve(folder.user)).to include comment
     end

--- a/spec/requests/sign_comment_spec.rb
+++ b/spec/requests/sign_comment_spec.rb
@@ -108,6 +108,7 @@ RSpec.describe "sign_comment", type: :request do
 
       it "retains the folder context of a comment" do
         folder = FactoryBot.create(:folder, user: user)
+        sign.folders << folder
         create_params[:folder_id] = folder.id
         create.call(sign)
         comment = sign.sign_comments.last

--- a/spec/requests/sign_spec.rb
+++ b/spec/requests/sign_spec.rb
@@ -41,6 +41,27 @@ RSpec.describe "sign", type: :request do
       expect { get sign_path(sign, comments_page: 2) }.to change(SignCommentActivity.read, :count).by(5)
     end
 
+    it "marks each seen comment's replies as read" do
+      unread = FactoryBot.create(:sign_comment, sign: sign)
+      reply_depth_1 = FactoryBot.create(:sign_comment, sign: sign, in_reply_to: unread)
+      reply_depth_2 = FactoryBot.create(:sign_comment, sign: sign, in_reply_to: reply_depth_1)
+
+      expect { get sign_path(sign) }.to change(SignCommentActivity.read, :count).by(3)
+      expect(unread).to be_read_by(user)
+      expect(reply_depth_1).to be_read_by(user)
+      expect(reply_depth_2).to be_read_by(user)
+    end
+
+    it "marks an unread reply as read, even if the original comment is already read" do
+      read = FactoryBot.create(:sign_comment, sign: sign)
+      read.read_by!(user)
+      reply = FactoryBot.create(:sign_comment, sign: sign, in_reply_to: read)
+
+      expect { get sign_path(sign) }.to change(SignCommentActivity.read, :count).by(1)
+      expect(read).to be_read_by(user)
+      expect(reply).to be_read_by(user)
+    end
+
     it "doesn't mark comments as read when there is no user signed in" do
       sign_out :user
       FactoryBot.create(:sign_comment, sign: sign)


### PR DESCRIPTION
1. Change indicator colour from royal blue to the orange accent colour

![image](https://user-images.githubusercontent.com/292020/214443689-3e3639c0-441d-421a-baf9-bd375b5b9e40.png)

2. Recursively mark comment replies as read to make sure that viewing a comment with nested replies correctly clears the unread indicator
3. Resolve a scoping issue that overcounted comments when a sign was removed from a folder that it has comments for