### PR TITLE
NZSL-65 Added emails for publishing and declining signs

### DIFF
--- a/app/mailers/sign_workflow_mailer.rb
+++ b/app/mailers/sign_workflow_mailer.rb
@@ -5,4 +5,18 @@ class SignWorkflowMailer < ApplicationMailer
 
     mail bcc: moderators
   end
+
+  def published(sign)
+    @contributor = sign.contributor
+    @sign = sign
+
+    mail to: @contributor.email
+  end
+
+  def declined(sign)
+    @contributor = sign.contributor
+    @sign = sign
+
+    mail to: @contributor.email
+  end
 end

--- a/app/models/sign.rb
+++ b/app/models/sign.rb
@@ -84,8 +84,10 @@ class Sign < ApplicationRecord
     state :personal, initial: true
     state :submitted, before_enter: -> { self.submitted_at = Time.zone.now },
                       after_enter: -> { SignWorkflowMailer.moderation_requested(self).deliver_later }
-    state :published, before_enter: -> { self.published_at = Time.zone.now }
-    state :declined, before_enter: -> { self.declined_at = Time.zone.now }
+    state :published, before_enter: -> { self.published_at = Time.zone.now },
+                      after_enter: -> { SignWorkflowMailer.published(self).deliver_later }
+    state :declined, before_enter: -> { self.declined_at = Time.zone.now },
+                     after_enter: -> { SignWorkflowMailer.declined(self).deliver_later }
     state :unpublish_requested, before_enter: -> { self.requested_unpublish_at = Time.zone.now }
     state :archived
 

--- a/app/views/sign_workflow_mailer/declined.text.erb
+++ b/app/views/sign_workflow_mailer/declined.text.erb
@@ -1,0 +1,7 @@
+Kia Ora <%= @contributor.username %>
+
+Your sign for the word <%= @sign.word %> has unfortunately been declined.
+
+If you have any questions, please contact <%= Rails.application.config.contact_email %>.
+
+<%= nzsl_text_signature %>

--- a/app/views/sign_workflow_mailer/published.text.erb
+++ b/app/views/sign_workflow_mailer/published.text.erb
@@ -1,0 +1,7 @@
+Kia Ora <%= @contributor.username %>
+
+Your sign for the word <%= @sign.word %> has been approved, it has now been published.
+
+If you have any questions, please contact <%= Rails.application.config.contact_email %>.
+
+<%= nzsl_text_signature %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -193,6 +193,10 @@ en:
   sign_workflow_mailer:
     moderation_requested:
       subject: NZSL Share - Submitted sign requires moderation
+    published:
+      subject: NZSL Share - Your sign has been published
+    declined:
+      subject: NZSL Share - Your sign has been declined
   collaboration_mailer:
     success:
       subject: NZSL Share - You are invited to join a team

--- a/spec/mailers/previews/sign_workflow_mailer_preview.rb
+++ b/spec/mailers/previews/sign_workflow_mailer_preview.rb
@@ -4,4 +4,14 @@ class SignWorkflowMailerPreview < ActionMailer::Preview
     sign = FactoryBot.build_stubbed(:sign, :submitted)
     SignWorkflowMailer.moderation_requested(sign)
   end
+
+  def published
+    sign = FactoryBot.build_stubbed(:sign, :published)
+    SignWorkflowMailer.published(sign)
+  end
+
+  def declined
+    sign = FactoryBot.build_stubbed(:sign, :declined)
+    SignWorkflowMailer.declined(sign)
+  end
 end

--- a/spec/mailers/sign_workflow_mailer_spec.rb
+++ b/spec/mailers/sign_workflow_mailer_spec.rb
@@ -25,4 +25,50 @@ RSpec.describe SignWorkflowMailer, type: :mailer do
       expect(mail.body.decoded).to include "#{sign.contributor.username} has submitted the sign #{sign.word}"
     end
   end
+
+  describe ".published" do
+    let(:sign) { FactoryBot.build_stubbed(:sign, :published) }
+
+    subject(:mail) do
+      mailer = described_class.new
+      mailer.process(:published, sign)
+
+      mailer.message
+    end
+
+    it "sends mail to the sign's contributor" do
+      expect(mail.to).to eq [sign.contributor.email]
+    end
+
+    it "has the expected subject" do
+      expect(mail.subject).to eq I18n.t!("sign_workflow_mailer.published.subject")
+    end
+
+    it "has the expected body text" do
+      expect(mail.body.decoded).to include "Your sign for the word #{sign.word} has been approved"
+    end
+  end
+
+  describe ".declined" do
+    let(:sign) { FactoryBot.build_stubbed(:sign, :declined) }
+
+    subject(:mail) do
+      mailer = described_class.new
+      mailer.process(:declined, sign)
+
+      mailer.message
+    end
+
+    it "sends mail to the sign's contributor" do
+      expect(mail.to).to eq [sign.contributor.email]
+    end
+
+    it "has the expected subject" do
+      expect(mail.subject).to eq I18n.t!("sign_workflow_mailer.declined.subject")
+    end
+
+    it "has the expected body text" do
+      expect(mail.body.decoded).to include "Your sign for the word #{sign.word} has unfortunately been declined."
+    end
+  end
 end

--- a/spec/models/sign_spec.rb
+++ b/spec/models/sign_spec.rb
@@ -148,6 +148,34 @@ RSpec.describe Sign, type: :model do
     end
   end
 
+  describe "#publish" do
+    let(:model) { FactoryBot.create(:sign, :submitted) }
+    subject { model.publish! }
+
+    it "changes the status to published" do
+      expect { subject }.to change(model, :status).to eq "published"
+    end
+
+    it "sends an email notification to the contributor" do
+      ActiveJob::Base.queue_adapter = :test
+      expect { subject }.to have_enqueued_mail(SignWorkflowMailer, :published)
+    end
+  end
+
+  describe "#decline" do
+    let(:model) { FactoryBot.create(:sign, :submitted) }
+    subject { model.decline! }
+
+    it "changes the status to declined" do
+      expect { subject }.to change(model, :status).to eq "declined"
+    end
+
+    it "sends an email notification to the contributor" do
+      ActiveJob::Base.queue_adapter = :test
+      expect { subject }.to have_enqueued_mail(SignWorkflowMailer, :declined)
+    end
+  end
+
   describe "#unpublish" do
     let(:model) { FactoryBot.create(:sign, :published) }
     before { allow(ArchiveSign).to receive_message_chain(:new, :process) }


### PR DESCRIPTION
This PR adds emails that are sent to a sign's contributer when that sign is published or when it is declined.