### PR TITLE
NZSL-57: Respect existing scope when querying for comments

### DIFF
--- a/app/policies/sign_comment_policy.rb
+++ b/app/policies/sign_comment_policy.rb
@@ -65,12 +65,12 @@ class SignCommentPolicy < ApplicationPolicy
 
   class Scope < Scope
     def resolve
-      accessible_signs = SignPolicy::Scope.new(user, Sign).resolve
+      accessible_signs = SignPolicy::Scope.new(user, Sign.where(id: scope.pluck(:sign_id))).resolve
       folder_ids = accessible_signs.left_outer_joins(:folders).pluck("folders.id").compact
       accessible_folders = FolderPolicy::Scope.new(user, Folder.where(id: folder_ids)).resolve
 
       scope
-        .where(sign_id: accessible_signs)
+        .where(sign_id: accessible_signs.pluck("signs.id"))
         .where(folder_id: [nil, *accessible_folders])
     end
   end


### PR DESCRIPTION
This prevents us counting comments on the sign when the user has access to a folder that a comment is in, but via a different sign to the one we are looking for comments on. I originally included this in the previous PR for NZSL-57, but removed it to save a query because I didn't think it was needed. It is actually needed, since not scoping the accessible signs affects the folders that are returned to us, which can affect the comment results.