### PR TITLE
NZSL-64: Update sign video for an entry

### DIFF
--- a/app/frontend/components/create-sign-form.js
+++ b/app/frontend/components/create-sign-form.js
@@ -1,12 +1,11 @@
 import Rails from "@rails/ujs";
 import uppyFileUpload from "./uppy-file-upload";
 import { post } from "@rails/request.js";
+import signVideoRestrictions from "./uppy/signVideoRestrictions";
 
 $(document).on("upload-success", "#new_sign .file-upload", () =>
   Rails.fire($("#new_sign").get(0), "submit")
 );
-
-const maxFileSizeMb = 250;
 
 const createSignController = (container) => {
   container.innerHTML = null; // Reset the container before adding Uppy
@@ -31,10 +30,8 @@ const createSignController = (container) => {
 
   uppy.setOptions({
     restrictions: {
-      maxFileSize: maxFileSizeMb * 1024 * 1024,
+      ...signVideoRestrictions,
       maxNumberOfFiles: maxNumberOfFiles,
-      minNumberOfFiles: 1,
-      allowedFileTypes: ["video/*", "application/mp4"],
     },
     locale: {
       strings: {

--- a/app/frontend/components/edit-sign-form.js
+++ b/app/frontend/components/edit-sign-form.js
@@ -1,10 +1,61 @@
-
 import { initialHTML, errorHTML } from "./file-upload";
+import uppyFileUpload from "./uppy-file-upload";
+import signVideoRestrictions from "./uppy/signVideoRestrictions";
+import { put } from "@rails/request.js";
 
+const updateSignVideo = (signId, signedBlobId) => {
+  return put(`/signs/${signId}`, {
+    body: JSON.stringify({
+      sign: { video: signedBlobId },
+    }),
+  }).then((response) => {
+    if (!response.ok) {
+      return Promise.reject(
+        new Error("Something went wrong creating this sign.")
+      );
+    }
+  });
+};
+
+const updateSignVideoController = (container) => {
+  const signId = container.dataset.updateSignVideoSignIdValue;
+
+  if (!signId) {
+    console.error(
+      "Missing required value [data-update-sign-video-sign-id-value]"
+    );
+    return;
+  }
+
+  const uppy = uppyFileUpload(container, {
+    uppy: { restrictions: signVideoRestrictions },
+    dashboard: {
+      hideRetryButton: true,
+      inline: false,
+      trigger: container.querySelector(
+        "[data-update-sign-video-target='trigger']"
+      ),
+    },
+  });
+
+  uppy.addPostProcessor(([fileId]) => {
+    const file = uppy.getFile(fileId);
+    uppy.emit("postprocess-progress", file, {
+      mode: "indeterminate",
+      message: "Creating signs...",
+    });
+
+    updateSignVideo(signId, file.response.signed_id).then(() => {
+      window.location.reload();
+    });
+  });
+};
 
 const handleSignAttachmentUpload = ($container, listSelector, path) => {
   const $content = $container.find(".file-upload__content");
-  const $field = $container.find(`input[name="${$container.data("fileUploadController")}"]`);
+  const $field = $container.find(
+    `input[name="${$container.data("fileUploadController")}"]`
+  );
   const signId = $container.data("signId");
   const signedBlobId = $field.val();
 
@@ -17,28 +68,61 @@ const handleSignAttachmentUpload = ($container, listSelector, path) => {
       $field.filter("input[type='hidden']").remove();
       $content.html(initialHTML(fieldName));
     })
-    .fail(xhr => {
+    .fail((xhr) => {
       let errorMessage = "Something went wrong.";
-      if (xhr.status === 422) { errorMessage = xhr.responseJSON.join(", "); }
+      if (xhr.status === 422) {
+        errorMessage = xhr.responseJSON.join(", ");
+      }
 
       $content.html(errorHTML(errorMessage));
     });
 };
 
-const handleAttachmentRemoval = (type) => $(`.sign-${type}`).load(`${window.location} .sign-${type} > *`);
+const handleAttachmentRemoval = (type) =>
+  $(`.sign-${type}`).load(`${window.location} .sign-${type} > *`);
 
 $(document).on("upload-success", ".usage-examples-file-upload", (event) =>
-  handleSignAttachmentUpload($(event.target), ".sign-usage-examples", "usage_examples"));
+  handleSignAttachmentUpload(
+    $(event.target),
+    ".sign-usage-examples",
+    "usage_examples"
+  )
+);
 $(document).on("upload-success", ".illustrations-file-upload", (event) =>
-  handleSignAttachmentUpload($(event.target), ".sign-illustrations", "illustrations"));
+  handleSignAttachmentUpload(
+    $(event.target),
+    ".sign-illustrations",
+    "illustrations"
+  )
+);
 
-$(document).on("ajax:success", ".sign-usage-examples a[data-method='delete']", () => handleAttachmentRemoval("usage-examples"));
-$(document).on("ajax:success", ".sign-illustrations a[data-method='delete']", () => handleAttachmentRemoval("illustrations"));
+$(document).on(
+  "ajax:success",
+  ".sign-usage-examples a[data-method='delete']",
+  () => handleAttachmentRemoval("usage-examples")
+);
+$(document).on(
+  "ajax:success",
+  ".sign-illustrations a[data-method='delete']",
+  () => handleAttachmentRemoval("illustrations")
+);
 
 $(document).on("blur keydown", ".js-attachment-description", (event) => {
-  if (event.keyCode && event.keyCode !== 13) { return; }
+  if (event.keyCode && event.keyCode !== 13) {
+    return;
+  }
 
   event.preventDefault();
   const input = event.target;
-  return $.ajax({ url: input.formAction, method: "PATCH", data: { format: "js", description: input.value } });
+  return $.ajax({
+    url: input.formAction,
+    method: "PATCH",
+    data: { format: "js", description: input.value },
+  });
+});
+
+$(() => {
+  $("[data-controller='update-sign-video']").each((_idx, container) =>
+    updateSignVideoController(container)
+  );
 });

--- a/app/frontend/components/uppy-file-upload.js
+++ b/app/frontend/components/uppy-file-upload.js
@@ -8,6 +8,7 @@ import ActiveStorageUpload from "./uppy/ActiveStorageUpload";
 const uppyFileUpload = (container, options = {}) => {
   const uppy = new Uppy({
     id: container.id,
+    ...options.uppy
   });
 
   uppy.use(DropTarget, { target: document.body });
@@ -26,7 +27,6 @@ const uppyFileUpload = (container, options = {}) => {
   uppy.use(ActiveStorageUpload, { directUploadUrl: "/rails/active_storage/direct_uploads" });
 
   uppy.use(Dashboard, {
-    ...options.dashboard,
     inline: true,
     target: container,
     proudlyDisplayPoweredByUppy: false,
@@ -36,7 +36,8 @@ const uppyFileUpload = (container, options = {}) => {
         dropPasteImportFiles: "Drop files here, or %{browseFiles}"
       }
     },
-    plugins: ["Webcam"]
+    plugins: ["Webcam"],
+    ...options.dashboard,
   });
 
   return uppy;

--- a/app/frontend/components/uppy/signVideoRestrictions.js
+++ b/app/frontend/components/uppy/signVideoRestrictions.js
@@ -1,0 +1,9 @@
+export const maxFileSizeMb = 250;
+export const restrictions = {
+  maxFileSize: maxFileSizeMb * 1024 * 1024,
+  maxNumberOfFiles: 1,
+  minNumberOfFiles: 1,
+  allowedFileTypes: ["video/*", "application/mp4"],
+};
+
+export default restrictions;

--- a/app/services/sign_creator.rb
+++ b/app/services/sign_creator.rb
@@ -1,33 +1,19 @@
-class SignBuilder
+class SignCreator
   attr_reader :sign
 
-  delegate :valid?, to: :sign
-
-  def build(sign_params)
+  def initialize(sign_params)
+    @sign_params = sign_params
     @sign = Sign.new(sign_params).tap do |sign|
       sign.word.presence || (sign.word = derive_word_from_attachment(sign.video))
     end
-
-    self
   end
 
-  def save!
-    @sign.save!
-    post_process
+  def create
+    return unless @sign.save
 
-    true
-  end
-
-  def save
-    save!
-  rescue ActiveRecord::RecordInvalid
-    false
-  end
-
-  private
-
-  def post_process
     SignPostProcessor.new(@sign).process
+
+    @sign
   end
 
   def derive_word_from_attachment(attachment)

--- a/app/services/sign_updater.rb
+++ b/app/services/sign_updater.rb
@@ -1,0 +1,14 @@
+class SignUpdater
+  def initialize(sign, sign_params)
+    @sign = sign
+    @sign_params = sign_params
+  end
+
+  def update
+    return unless @sign.update(@sign_params)
+
+    SignPostProcessor.new(@sign).process if @sign_params.key?(:video)
+
+    @sign
+  end
+end

--- a/app/views/signs/edit.html.erb
+++ b/app/views/signs/edit.html.erb
@@ -17,7 +17,7 @@
     <fieldset class="form__section">
       <legend><h2 class="primary">Sign details</h2></legend>
       <hr class="form__divider">
-      <div class="file-preview js-sign-video-container">
+      <div class="file-preview js-sign-video-container" data-controller="update-sign-video" data-update-sign-video-sign-id-value="<%= @sign.to_param %>">
         <div class="file-preview__media">
           <%= render "signs/card/video", sign: @sign, overlay: false %>
         </div>
@@ -30,6 +30,8 @@
           <span class="file-preview__metadata__value">
             <%= number_to_human_size @sign.video.byte_size %>
           </span>
+
+          <%= button_tag "Change video", class: "button clear", type: "button", data: { update_sign_video_target: "trigger" } %>
         </div>
       </div>
 

--- a/spec/requests/sign_spec.rb
+++ b/spec/requests/sign_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 
 RSpec.describe "sign", type: :request do
   let(:user) { FactoryBot.create(:user, :approved) }
-  let(:sign) { FactoryBot.create(:sign, :published, contributor: user) }
+  let(:sign) { FactoryBot.create(:sign, contributor: user) }
 
   before { sign_in user }
 
@@ -31,8 +31,25 @@ RSpec.describe "sign", type: :request do
   end
 
   describe "PATCH /:id" do
+    let(:sign_params) { { notes: "this is a note for a sign" } }
     let(:update) do
-      ->(sign) { patch "/signs/#{sign.id}", params: { sign: { notes: "this is a note for a sign" } } }
+      ->(sign) { patch "/signs/#{sign.id}", params: { sign: sign_params } }
+    end
+
+    it "post-processes sign videos when it is provided" do
+      new_video = fixture_file_upload("spec/fixtures/small.mp4")
+      sign_params[:video] = new_video
+      allow(SignPostProcessor).to receive(:new).and_return(double.as_null_object)
+      update.call(sign)
+
+      expect(SignPostProcessor).to have_received(:new).with(sign)
+    end
+
+    it "does not post process sign videos when the sign video is not provided" do
+      allow(SignPostProcessor).to receive(:new)
+      update.call(sign)
+
+      expect(SignPostProcessor).not_to have_received(:new).with(sign)
     end
 
     it "does not change sign ownership after update" do
@@ -43,6 +60,8 @@ RSpec.describe "sign", type: :request do
   end
 
   describe "GET show" do
+    let(:sign) { FactoryBot.create(:sign, :published, contributor: user) }
+
     it "marks unseen comments as read" do
       read = FactoryBot.create_list(:sign_comment, 5, sign: sign).each do |comment|
         comment.read_by!(user)

--- a/spec/services/sign_creator_spec.rb
+++ b/spec/services/sign_creator_spec.rb
@@ -1,8 +1,8 @@
 require "rails_helper"
 
-RSpec.describe SignBuilder, type: :service do
-  describe ".build" do
-    subject { SignBuilder.new.build(attrs).sign }
+RSpec.describe SignCreator, type: :service do
+  describe ".initialize" do
+    subject { SignCreator.new(attrs).sign }
 
     context "word is already present" do
       let(:attrs) { FactoryBot.attributes_for(:sign) }
@@ -30,11 +30,11 @@ RSpec.describe SignBuilder, type: :service do
     end
   end
 
-  describe ".save" do
+  describe ".create" do
     let(:attrs) { FactoryBot.attributes_for(:sign).merge(contributor: FactoryBot.build(:user)) }
-    let(:builder) { SignBuilder.new.build(attrs) }
-    let(:sign) { builder.sign }
-    subject { builder.save! }
+    let(:creator) { SignCreator.new(attrs) }
+    let(:sign) { creator.sign }
+    subject { creator.create }
 
     it "persists the sign record" do
       expect { subject }.to change(sign, :persisted?).to(true)

--- a/spec/services/sign_ownership_transfer_service_spec.rb
+++ b/spec/services/sign_ownership_transfer_service_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe SignBuilder, type: :service do
+RSpec.describe SignOwnershipTransferService, type: :service do
   describe ".transfer_sign" do
     subject { SignOwnershipTransferService.new }
 

--- a/spec/services/sign_updater_spec.rb
+++ b/spec/services/sign_updater_spec.rb
@@ -1,0 +1,31 @@
+require "rails_helper"
+
+RSpec.describe SignUpdater, type: :service do
+  let(:sign) { FactoryBot.create(:sign) }
+
+  describe ".update" do
+    it "updates the record" do
+      expect { described_class.new(sign, { notes: "Test notes" }).update }.to change(sign, :notes)
+    end
+
+    it "post-processes the record when the video is provided" do
+      processor = instance_spy(SignPostProcessor)
+      allow(SignPostProcessor).to receive(:new).and_return(processor)
+      described_class.new(sign, { video: fixture_file_upload("spec/fixtures/small.mp4") }).update
+      expect(processor).to have_received(:process)
+    end
+
+    it "does not post-process the record when the video is not provided" do
+      allow(SignPostProcessor).to receive(:new)
+      described_class.new(sign, { notes: "My cool record" }).update
+      expect(SignPostProcessor).not_to have_received(:new)
+    end
+
+    it "does not post-process the record when the record is invalid" do
+      allow(SignPostProcessor).to receive(:new)
+      described_class.new(sign, { word: "" }).update
+      expect(sign.errors[:word]).to eq ["can't be blank"]
+      expect(SignPostProcessor).not_to have_received(:new)
+    end
+  end
+end


### PR DESCRIPTION
This pull request is the first feature that uses Uppy without a fallback, since this is new functionality.

This presents Uppy in a modal after clicking "Change video" on a sign. This allows selection of a single file, and then updates the sign with the new video. When the video is submitted, we update the sign to re-queue the new video for processing (thumbnail generation and encoding).

This needed a bit of tidying up to make sure the creation and updating process is consistent in terms of the post-processing.  I'm aware that the create and update javascript for sign videos has quite a bit of replication. I had a few ideas about how to tidy this up, but none of them really worked out. Possibly with Stimulus wrapped around this functionality it could become slightly easier.


https://user-images.githubusercontent.com/292020/215618090-d7021404-3fb9-499c-96f6-185be930aa80.mp4

