### PR TITLE
NZSL-102: Add checkbox to allow table rows to be selected for bulk processing

### DIFF
--- a/app/views/signs/_table_row.html.erb
+++ b/app/views/signs/_table_row.html.erb
@@ -2,7 +2,14 @@
 
 <tr class="sign-table-row">
   <td>
-    <%= image_tag(url_for(sign.video.preview(ThumbnailPreset.default.scale_360.to_h).image)) %>
+    <div class="checkbox">
+      <%= check_box_tag "sign_ids[]", sign.id, params[:sign_ids]&.include?(sign.id), id: dom_id(sign, :batch_selection) %>
+      <%= label_tag dom_id(sign, :batch_selection) do %>
+        <span class="show-for-sr">Add sign to selection</span>
+      <% end %>
+    </div>
+  <td>
+    <%= image_tag(sign.poster_url(size: 360)) %>
   </td>
 
   <td>

--- a/app/views/signs/index.html.erb
+++ b/app/views/signs/index.html.erb
@@ -9,7 +9,7 @@
     <table class="max-width-100">
       <thead>
         <tr>
-          <td>Video</td>
+          <td colspan="2">Video</td>
           <td>Word</td>
           <td>Status</td>
           <td>Submitted</td>

--- a/app/views/signs/index.js.erb
+++ b/app/views/signs/index.js.erb
@@ -1,3 +1,3 @@
-$(".sign-grid").append("<%= escape_javascript render partial: "card", collection: @signs, as: :sign%>");
+$(".sign-grid > table > tbody").append("<%= escape_javascript render partial: "table_row", collection: @signs, as: :sign%>");
 $(".show-more").replaceWith("<%= escape_javascript render partial: "show_more" %>");
 

--- a/spec/views/signs/_table_row.html.erb_spec.rb
+++ b/spec/views/signs/_table_row.html.erb_spec.rb
@@ -1,0 +1,18 @@
+require "rails_helper"
+
+RSpec.describe "signs/_table_row.html.erb", type: :view do
+  let(:sign) { FactoryBot.build_stubbed(:sign, :published) }
+
+  before { stub_authorization }
+
+  it "renders a checkbox for batch selection" do
+    rendered = render "signs/table_row", sign: sign
+    expect(rendered).to have_field("Add sign to selection", checked: false)
+  end
+
+  it "checks the batch selection checkbox when an appropriate param is present" do
+    params[:sign_ids] = [sign.id]
+    rendered = render "signs/table_row", sign: sign
+    expect(rendered).to have_field("Add sign to selection", checked: true)
+  end
+end


### PR DESCRIPTION
This pull request adds a checkbox to each table row on the 'My Signs' page that allows selection of one or more table rows to apply bulk actions to. 

The bulk actions are not yet implemented, this PR just adds the UI to select rows. I also found and fixed an issue where 'Show more' would load sign cards into the table, instead of rows.

![image](https://user-images.githubusercontent.com/292020/216185858-36913e6b-ad7d-45d5-b931-a68e6656dce8.png)
