### PR TITLE
Add active_storage_purge queue to the list of queues Sidekiq will work off

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,6 +1,7 @@
 ---
 :queues:
   - default
+  - actuve_storage_purge
   - active_storage_analysis
   - video_encoding
   - thumbnail_generation

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,7 +1,7 @@
 ---
 :queues:
   - default
-  - actuve_storage_purge
+  - active_storage_purge
   - active_storage_analysis
   - video_encoding
   - thumbnail_generation


### PR DESCRIPTION
Since we didn't have this queue active, we were destroying blobs, but not their underlying files. This doesn't really impact the application functionality, but means we're storing files unnecessarily.

This change adds the purge queue to the list of queues that Sidekiq will work off, so we can correctly purge unused files.