### PR TITLE
NZSL-64: Add the sign video blob ID into the poster URL cache key, so that the poster cache is expired when the video changes

### DIFF
--- a/app/presenters/sign_presenter.rb
+++ b/app/presenters/sign_presenter.rb
@@ -66,7 +66,7 @@ class SignPresenter < ApplicationPresenter # rubocop:disable Metrics/ClassLength
     # We do not use the 'sign' instance here, because we want this cache
     # to not expire unless the variation key changes. If we use the sign instance,
     # the cache expires each time the sign is changed at all.
-    Rails.cache.fetch([:signs, sign.id, :poster_url, preview.variation.key]) do
+    Rails.cache.fetch([:signs, sign.id, video.blob_id, :poster_url, preview.variation.key]) do
       preview.processed # Ensure the preview is processed
       h.url_for(preview.image)
     end


### PR DESCRIPTION
This pull request resolves a bug with NZSL-64, where the poster URL is cached, even when the sign video is changed.
To fix this issue, I've mixed the sign video blob ID into the cache key for the poster. When the blob is changed (e.g. the video is edited), we now recalculate the cache key and return the correct preview representation.