### PR TITLE
NZSL-65: Adjust wording for accepted/declined mailer templates

### DIFF
--- a/app/views/sign_workflow_mailer/declined.text.erb
+++ b/app/views/sign_workflow_mailer/declined.text.erb
@@ -1,6 +1,6 @@
 Kia Ora <%= @contributor.username %>
 
-Your sign for the word <%= @sign.word %> has unfortunately been declined.
+Your sign ‘<%= @sign.word %>’ has been declined.
 
 If you have any questions, please contact <%= Rails.application.config.contact_email %>.
 

--- a/app/views/sign_workflow_mailer/published.text.erb
+++ b/app/views/sign_workflow_mailer/published.text.erb
@@ -1,6 +1,6 @@
 Kia Ora <%= @contributor.username %>
 
-Your sign for the word <%= @sign.word %> has been approved, it has now been published.
+Your sign ‘<%= @sign.word %>’ has been approved, it has now been published.
 
 If you have any questions, please contact <%= Rails.application.config.contact_email %>.
 

--- a/spec/mailers/sign_workflow_mailer_spec.rb
+++ b/spec/mailers/sign_workflow_mailer_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe SignWorkflowMailer, type: :mailer do
     end
 
     it "has the expected body text" do
-      expect(mail.body.decoded).to include "Your sign for the word #{sign.word} has been approved"
+      expect(mail.body.decoded).to include "Your sign ‘#{sign.word}’ has been approved"
     end
   end
 
@@ -68,7 +68,7 @@ RSpec.describe SignWorkflowMailer, type: :mailer do
     end
 
     it "has the expected body text" do
-      expect(mail.body.decoded).to include "Your sign for the word #{sign.word} has unfortunately been declined."
+      expect(mail.body.decoded).to include "Your sign ‘#{sign.word}’ has been declined"
     end
   end
 end


### PR DESCRIPTION
A small wording change for sign workflow email templates to use language consistent with how DSRU/NZSL Share refers to signs.

Approved:

```
Kia Ora patrick4

Your sign ‘Reuben’ has been approved, it has now been published.

If you have any questions, please contact test@example.com.

Kind regards

NZSL Share Team

NZSL Share: https://nzslshare.nz
NZSL Online Dictionary: https://nzsl.nz
Learn NZSL: http://www.learnnzsl.nz
Email: DSRU@vuw.ac.nz
```

Declined:

```
Kia Ora minerva8

Your sign ‘Warner’ has been declined.

If you have any questions, please contact test@example.com.

Kind regards

NZSL Share Team

NZSL Share: https://nzslshare.nz
NZSL Online Dictionary: https://nzsl.nz
Learn NZSL: http://www.learnnzsl.nz
Email: DSRU@vuw.ac.nz
```