### PR TITLE
NZSL-126: Implement contributor information

### DIFF
--- a/app/frontend/components/_sign-table.scss
+++ b/app/frontend/components/_sign-table.scss
@@ -160,11 +160,32 @@
 
   &__contributor {
     color: inherit;
-    font-weight: normal;
     text-decoration: none;
+    flex-direction: row;
+    justify-content: flex-start;
+    display: flex;
+    margin: -1rem 0;
 
-    &:hover {
-      color: get-color(royal);
+    @include breakpoint(large up) {
+      margin: 0;
+    }
+
+    &__icon {
+      margin-top: 0.375rem;
+      margin-right: 0.375rem;
+    }
+
+    &__info {
+      display: flex;
+      flex-direction: row;
+
+      @include breakpoint(large up) {
+        flex-direction: column;
+      }
+    }
+
+    a, a:hover {
+      font-weight: normal;
       text-decoration: underline;
     }
   }

--- a/app/frontend/components/_sign-table.scss
+++ b/app/frontend/components/_sign-table.scss
@@ -42,7 +42,12 @@
     }
   }
 
-  a {
+  &__row {
+    color: $neutral-gray;
+  }
+
+  a:not(.button) {
+    color: inherit;
     text-decoration: none;
   }
 
@@ -139,7 +144,6 @@
 
   &__subtitle {
     font-weight: 400;
-    color: $neutral-gray;
     font-size: 1rem;
   }
 
@@ -173,7 +177,6 @@
     &--agree,
     &--disagree,
     &--comments {
-      color: get-color(medium) !important;
       display: inline-flex;
       text-decoration: none;
       margin-right: 0.625rem;

--- a/app/views/signs/table/_row.html.erb
+++ b/app/views/signs/table/_row.html.erb
@@ -34,11 +34,19 @@
   </td>
 
   <td class="sign-table__cell">
-    <%= inline_svg_pack_tag "media/images/user.svg", aria_hidden: true %>
-    <%= link_to user_path(sign.contributor.username), class: "sign-table__contributor" do %>
-      <%= sign.contributor.username %>
-    <% end %>
-    <div><%= sign.friendly_date %></div>
+    <div class="sign-table__contributor">
+      <%= inline_svg_pack_tag "media/images/user.svg", aria_hidden: true, class: "sign-table__contributor__icon" %>
+
+      <div class="sign-table__contributor__info">
+        <%= link_to user_path(sign.contributor.username) do %>
+          <%= sign.contributor.username %>
+        <% end %>
+        <div>
+          <span class="hide-for-large">&nbsp;|&nbsp;</span>
+          <%= sign.friendly_date %>
+        </div>
+      </div>
+    </div>
   </td>
 
   <td class="sign-table__cell sign-table__controls">


### PR DESCRIPTION
This pull request implements the contributor information from Figma. It's basically a bunch of Flexbox to have a 2-column layout (icon + info) that unwraps into a single line on small screens. The method to add a divider between the two info elements (username + date), but I was already upset about the amount of classes for this. Happy to take feedback if it looks _too_ gross. Same reason for negative margin on mobile - I just needed to pull the element up a little. Probably with design feedback, we should reduce the cell padding right across the cells, and then increase it just where necessary.

Small/medium:

![localhost_3000_user_signs (5)](https://user-images.githubusercontent.com/292020/217956047-50d536d4-f3ad-409c-b80e-0bbdb4c0ba31.png)

Large:

![image](https://user-images.githubusercontent.com/292020/217956111-28971ee8-6ccf-4196-a3b6-7596ae996b90.png)
