### PR TITLE
NZSL-129 Updated submit for publishing button styles

### DIFF
--- a/app/frontend/components/_sign-table.scss
+++ b/app/frontend/components/_sign-table.scss
@@ -192,12 +192,4 @@
       margin-right: 0.625rem;
     }
   }
-
-  &__mobile-margin {
-    margin-top: 0;
-
-    @include breakpoint(medium down) {
-      margin-top: 2.2rem;
-    }
-  }
 }

--- a/app/frontend/components/_sign-table.scss
+++ b/app/frontend/components/_sign-table.scss
@@ -192,4 +192,12 @@
       margin-right: 0.625rem;
     }
   }
+
+  &__mobile-margin {
+    margin-top: 0;
+
+    @include breakpoint(medium down) {
+      margin-top: 2.2rem;
+    }
+  }
 }

--- a/app/frontend/foundation/_settings.scss
+++ b/app/frontend/foundation/_settings.scss
@@ -117,7 +117,7 @@ $global-menu-padding: 1.5rem 1rem;
 $global-menu-nested-margin: 1rem;
 $global-text-direction: ltr;
 $global-flexbox: true;
-$global-prototype-breakpoints: false;
+$global-prototype-breakpoints: true;
 $global-button-cursor: auto;
 $global-color-pick-contrast-tolerance: 0;
 $contrast-warnings: false;

--- a/app/views/signs/table/_controls.html.erb
+++ b/app/views/signs/table/_controls.html.erb
@@ -12,10 +12,10 @@
   </div>
 
   <% if current_user.approved? %>
-    <div class="cell grid-x medium-4 medium-offset-4 small-12 align-right align-bottom">
+    <div class="cell grid-x large-3 large-offset-5 small-12 align-right align-bottom sign-table__mobile-margin">
       <%= f.button "Submit for publishing", value: :submit_for_publishing,
                                             name: :operation,
-                                            class: "button neutral",
+                                            class: "button neutral cell",
                                             data: { confirm: "I agree to follow the privacy policy - #{page_url("privacy-policy")}" } %>
     </div>
   <% end %>

--- a/app/views/signs/table/_controls.html.erb
+++ b/app/views/signs/table/_controls.html.erb
@@ -12,7 +12,7 @@
   </div>
 
   <% if current_user.approved? %>
-    <div class="cell grid-x large-3 large-offset-5 small-12 align-right align-bottom sign-table__mobile-margin">
+    <div class="cell grid-x large-3 large-offset-5 small-12 align-right align-bottom large-padding-top-0 padding-top-2">
       <%= f.button "Submit for publishing", value: :submit_for_publishing,
                                             name: :operation,
                                             class: "button neutral cell",


### PR DESCRIPTION
This PR updates the styling of the submit for publishing button based on feedback from Karyn.

This includes the following changes
- Updating the width of the button on mobile to 100% (through the use of the cell class)
- Updating the width of the button so that it matches the width of the sort dropdown above it (not something Karyn specifically gave feedback on but it better matches the designs and is a side effect of setting the width for small screens while trying to minimize the number of new classes)
- Adding a margin above the button to seperate it from the bulk assigning topics controls (this is done because in another story, they will be stacked vertically on mobile)

![Screenshot 2023-02-14 143401](https://user-images.githubusercontent.com/18455252/218615777-76d32be0-607b-4a86-bef6-6302ea4232ce.png)

![Screenshot 2023-02-14 143434](https://user-images.githubusercontent.com/18455252/218615771-6cbb62cb-7ab6-4fc1-993c-789b0a62c2d5.png)
