### PR TITLE
NZSL-128: Stack Assign button on small screens

### DIFF
--- a/app/frontend/foundation/_settings.scss
+++ b/app/frontend/foundation/_settings.scss
@@ -117,7 +117,7 @@ $global-menu-padding: 1.5rem 1rem;
 $global-menu-nested-margin: 1rem;
 $global-text-direction: ltr;
 $global-flexbox: true;
-$global-prototype-breakpoints: false;
+$global-prototype-breakpoints: true;
 $global-button-cursor: auto;
 $global-color-pick-contrast-tolerance: 0;
 $contrast-warnings: false;

--- a/app/views/signs/table/_controls.html.erb
+++ b/app/views/signs/table/_controls.html.erb
@@ -5,9 +5,9 @@
     <%= f.collection_select :topic_id, policy_scope(Topic).all,
                                        :id, :name,
                                        { prompt: "--Select topic--" },
-                                       class: "cell auto margin-right-2 margin-bottom-0" %>
-    <div class="cell shrink">
-      <%= f.button "Assign", value: :assign_topic, name: :operation, class: "button neutral" %>
+                                       class: "cell large-auto margin-right-2 margin-bottom-0" %>
+    <div class="cell large-shrink padding-top-1 large-padding-top-0">
+      <%= f.button "Assign", value: :assign_topic, name: :operation, class: "button neutral width-100" %>
     </div>
   </div>
 


### PR DESCRIPTION
This PR adds utility classes to the assign button to stack it to full-width on small screens

![image](https://user-images.githubusercontent.com/292020/219188536-6aa353da-bf5b-43ff-a04a-b4e05f958b60.png)

On larger screens, the existing behaviour is retained

![image](https://user-images.githubusercontent.com/292020/219188796-5fc51c79-fc89-4612-9a21-418a54e00831.png)
