### PR TITLE
NZSL-131: Improve bulk sign operation messaging

### DIFF
--- a/app/controllers/sign_batch_operations_controller.rb
+++ b/app/controllers/sign_batch_operations_controller.rb
@@ -63,9 +63,7 @@ class SignBatchOperationsController < ApplicationController
   end
 
   def sign_ids
-    params.require(:sign_ids)
-  rescue ActionController::ParameterMissing
-    redirect_to(user_signs_path, alert: t(".failure_missing_sign_ids"))
+    params.fetch(:sign_ids, [])
   end
 
   def signs

--- a/app/controllers/sign_batch_operations_controller.rb
+++ b/app/controllers/sign_batch_operations_controller.rb
@@ -72,7 +72,7 @@ class SignBatchOperationsController < ApplicationController
   def flash_messages_for_result(succeeded_records, failed_records)
     if !succeeded_records.empty? && failed_records.empty?
       { notice: t(".success", succeeded_count: succeeded_records.size) }
-    elsif !succeeded_records.empty?
+    elsif !succeeded_records.empty? || !failed_records.empty?
       { alert: t(".mixed_success", succeeded_count: succeeded_records.size, failed_count: failed_records.size) }
     else
       { alert: t(".failure_missing_sign_ids") }

--- a/app/controllers/sign_batch_operations_controller.rb
+++ b/app/controllers/sign_batch_operations_controller.rb
@@ -15,8 +15,7 @@ class SignBatchOperationsController < ApplicationController
       format.json { render json: { succeeded: succeeded, failed: failed } }
       format.html do
         redirect_to user_signs_path(sign_ids: sign_ids),
-                    notice: t(".success", succeeded_count: succeeded.size,
-                                          failed_count: failed.size)
+                    **flash_messages_for_result(succeeded, failed)
       end
     end
   end
@@ -68,5 +67,15 @@ class SignBatchOperationsController < ApplicationController
 
   def signs
     policy_scope(Sign.where(id: sign_ids)).limit(BULK_OPERATIONS_LIMIT)
+  end
+
+  def flash_messages_for_result(succeeded_records, failed_records)
+    if !succeeded_records.empty? && failed_records.empty?
+      { notice: t(".success", succeeded_count: succeeded_records.size) }
+    elsif !succeeded_records.empty?
+      { alert: t(".mixed_success", succeeded_count: succeeded_records.size, failed_count: failed_records.size) }
+    else
+      { alert: t(".failure_missing_sign_ids") }
+    end
   end
 end

--- a/app/controllers/sign_batch_operations_controller.rb
+++ b/app/controllers/sign_batch_operations_controller.rb
@@ -29,6 +29,8 @@ class SignBatchOperationsController < ApplicationController
       method(:assign_topic)
     when :submit_for_publishing
       method(:submit_for_publishing)
+    when :echo
+      method(:echo)
     else
       head(:unprocessable_entity)
     end
@@ -41,6 +43,12 @@ class SignBatchOperationsController < ApplicationController
 
   def assign_topic(record)
     record.topics << policy_scope(Topic).find(params.require(:topic_id))
+  end
+
+  ##
+  # Just used for testing, just succeed the record
+  def echo(record)
+    record
   end
 
   def submit_for_publishing(record)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -106,7 +106,7 @@ en:
   sign_batch_operations:
     create:
       success: You have successfully updated %{succeeded_count} sign(s)
-      mixed_success: You have successfully updated %{succeeded_count} sign(s)), but %{failed_count} sign(s) failed to update
+      mixed_success: You have successfully updated %{succeeded_count} sign(s), but %{failed_count} sign(s) failed to update
       failure_missing_sign_ids: No signs updated. Please select sign(s) before assigning updates
   search:
     sort_by:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -106,6 +106,7 @@ en:
   sign_batch_operations:
     create:
       success: Successfully processed %{succeeded_count} sign(s), %{failed_count} failed to process
+      failure_missing_sign_ids: No signs updated. Please select sign(s) before assigning updates
   search:
     sort_by:
       alpha_asc: Alphabetical (A-Z)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -105,7 +105,8 @@ en:
       success: Your sign, '%{sign_name}' has been removed from NZSL Share
   sign_batch_operations:
     create:
-      success: Successfully processed %{succeeded_count} sign(s), %{failed_count} failed to process
+      success: You have successfully updated %{succeeded_count} sign(s)
+      mixed_success: You have successfully updated %{succeeded_count} sign(s)), but %{failed_count} sign(s) failed to update
       failure_missing_sign_ids: No signs updated. Please select sign(s) before assigning updates
   search:
     sort_by:

--- a/spec/requests/sign_batch_operations_spec.rb
+++ b/spec/requests/sign_batch_operations_spec.rb
@@ -18,8 +18,8 @@ RSpec.describe "/signs/batch_operation", type: :request do
     it "responds with the expected HTML" do
       params = { operation: :echo, sign_ids: [sign.id] }
       post signs_batch_operations_path(params: params)
-      expect(response).to redirect_to user_signs_path(sign_ids: [1])
-      expect(flash[:notice]).to eq "Successfully processed 0 sign(s), 0 failed to process"
+      expect(response).to redirect_to user_signs_path(sign_ids: [sign.id])
+      expect(flash[:notice]).to eq "You have successfully updated 1 sign(s)"
     end
 
     it "rejects an invalid operation name" do

--- a/spec/requests/sign_batch_operations_spec.rb
+++ b/spec/requests/sign_batch_operations_spec.rb
@@ -28,6 +28,13 @@ RSpec.describe "/signs/batch_operation", type: :request do
       expect(response.status).to eq 422
     end
 
+    it "returns a flash message when there were no signs to process" do
+      params = { operation: :assign_topic, sign_ids: [] }
+      post signs_batch_operations_path(params: params)
+      expect(response).to redirect_to user_signs_path(sign_ids: [])
+      expect(flash[:alert]).to eq "No signs updated. Please select sign(s) before assigning updates"
+    end
+
     context "when topics are assigned to signs" do
       let(:topic) { FactoryBot.create(:topic) }
 

--- a/spec/requests/sign_batch_operations_spec.rb
+++ b/spec/requests/sign_batch_operations_spec.rb
@@ -8,15 +8,15 @@ RSpec.describe "/signs/batch_operation", type: :request do
     before { sign_in user }
 
     it "responds with the expected JSON" do
-      params = { operation: :assign_topic, sign_ids: [1] }
+      params = { operation: :echo, sign_ids: [sign.id] }
       post signs_batch_operations_path(params: params, format: :json)
       expect(response).to be_ok
       response_json = JSON.parse(response.body)
-      expect(response_json).to eq("succeeded" => [], "failed" => [])
+      expect(response_json).to eq("succeeded" => [sign.as_json], "failed" => [])
     end
 
     it "responds with the expected HTML" do
-      params = { operation: :assign_topic, sign_ids: [1] }
+      params = { operation: :echo, sign_ids: [sign.id] }
       post signs_batch_operations_path(params: params)
       expect(response).to redirect_to user_signs_path(sign_ids: [1])
       expect(flash[:notice]).to eq "Successfully processed 0 sign(s), 0 failed to process"
@@ -29,7 +29,7 @@ RSpec.describe "/signs/batch_operation", type: :request do
     end
 
     it "returns a flash message when there were no signs to process" do
-      params = { operation: :assign_topic, sign_ids: [] }
+      params = { operation: :echo, sign_ids: [] }
       post signs_batch_operations_path(params: params)
       expect(response).to redirect_to user_signs_path(sign_ids: [])
       expect(flash[:alert]).to eq "No signs updated. Please select sign(s) before assigning updates"

--- a/spec/system/my_signs_spec.rb
+++ b/spec/system/my_signs_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe "My Signs", type: :system do
     select topic_to_assign.name, from: "Assign topics"
     click_on "Assign"
 
-    expect(page).to have_content "Successfully processed 3 sign(s), 0 failed to process"
+    expect(page).to have_content "You have successfully updated 3 sign(s)"
     expect(all(".sign-table__row input[name='sign_ids[]']")[0..2]).to all(be_checked)
   end
 
@@ -62,7 +62,7 @@ RSpec.describe "My Signs", type: :system do
     all(".sign-table__row input[name='sign_ids[]']")[0..2].each(&:check)
     click_on "Submit for publishing"
 
-    expect(page).to have_content "Successfully processed 3 sign(s), 0 failed to process"
+    expect(page).to have_content "You have successfully updated 3 sign(s)"
     expect(all(".sign-table__row input[name='sign_ids[]']")[0..2]).to all(be_checked)
   end
 


### PR DESCRIPTION
Adds messaging for complete success:

![image](https://user-images.githubusercontent.com/292020/219213898-b8bc2c47-74a9-4fa4-a819-a285614c85f2.png)


Partial success:

![image](https://user-images.githubusercontent.com/292020/219213857-624b2233-ec22-45ad-adef-79396f8690cf.png)


Failure:

![image](https://user-images.githubusercontent.com/292020/219213756-6bc46f95-8c57-413a-94cf-20b04d48f773.png)

When no signs are selected:

![image](https://user-images.githubusercontent.com/292020/219213927-e9532c0d-6a9c-4653-af04-48f8f3030ee4.png)
