### PR TITLE
Remove neutral button style, switch to primary, and add disabled button style while submitting

### DIFF
--- a/app/frontend/foundation/overrides/buttons.scss
+++ b/app/frontend/foundation/overrides/buttons.scss
@@ -70,16 +70,6 @@ $clear-button-palette: (
     }
   }
 
-  &.neutral {
-    color: $neutral-gray;
-    background: $white;
-    border: solid 1px get-color(light);
-
-    &:active, &:hover, &:focus {
-      border-color: $neutral-gray;
-    }
-  }
-
   &.alert {
     background: get-color(alert-x-light) !important;
     color: get-color(alert);

--- a/app/views/signs/table/_controls.html.erb
+++ b/app/views/signs/table/_controls.html.erb
@@ -7,7 +7,8 @@
                                        { prompt: "--Select topic--" },
                                        class: "cell large-auto margin-right-2 margin-bottom-0" %>
     <div class="cell large-shrink padding-top-1 large-padding-top-0">
-      <%= f.button "Assign", value: :assign_topic, name: :operation, class: "button neutral width-100" %>
+      <%= f.button "Assign", value: :assign_topic, name: :operation, class: "button primary width-100",
+                             data: { disable_with: "Assigning topic..." } %>
     </div>
   </div>
 
@@ -15,8 +16,10 @@
     <div class="cell grid-x large-3 large-offset-5 small-12 align-right align-bottom large-padding-top-0 padding-top-2">
       <%= f.button "Submit for publishing", value: :submit_for_publishing,
                                             name: :operation,
-                                            class: "button neutral cell",
-                                            data: { confirm: "I agree to follow the privacy policy - #{page_url("privacy-policy")}" } %>
+                                            class: "button primary cell",
+                                            data: {
+                                              disable_with: "Submitting...",
+                                              confirm: "I agree to follow the privacy policy - #{page_url("privacy-policy")}" } %>
     </div>
   <% end %>
 <% end %>


### PR DESCRIPTION
This is the last piece of design feedback for NZSL-101. Changes the button style from neutral (which was meant to be disabled state, something not clear in Figma), which is now unused and can be removed.

Also adds data-disable-with so that the buttons are not clickable while the form is submitting. I've cleared with Karyn that _both_ buttons disable when submitting.

![image](https://user-images.githubusercontent.com/292020/220217283-dc5aedd0-70b7-4e60-8aa9-13371cae2a6c.png)

https://user-images.githubusercontent.com/292020/220217324-675b7253-e813-41c4-b5f0-6761be7d5afa.mp4


