### PR TITLE
Add engines to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,10 @@
     "> 0.25% in NZ and last 2 versions",
     "not ie 11"
   ],
+  "engines": {
+    "node": "^16.19.1",
+    "yarn": "^1.0.0"
+  },
   "dependencies": {
     "@babel/plugin-transform-react-jsx": "^7.3.0",
     "@rails/actioncable": "^7.0.4",


### PR DESCRIPTION
Sorry @hopkincame, I steered you wrong last week. Heroku uses the [engines section of `package.json`](https://devcenter.heroku.com/articles/nodejs-support#specifying-a-node-js-version) to determine the node version, not .node-version. We use .node-version in [rails-template](https://github.com/ackama/rails-template/blob/97953776d61743e5d1bd6efa99c621cfb14bd054/template.rb#L206) to populate the engines field, but this repo predates that.

