### PR TITLE
Revert ActiveSupport::KeyGenerator.hash_digest_class from SHA256 to SHA1 to keep our variant signatures stable

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -39,6 +39,14 @@ module NzslShare
     # on forms for @rails/rails_ujs to handle these responses
     config.action_view.form_with_generates_remote_forms = true
 
+    ##
+    # In Rails 7, the hash digest class was changed to SHA256. We have many
+    # ActiveStorage keys that use this hash value as part of a variation key, so
+    # we are sticking with SHA1.
+    # The pathway to supporting SHA256 would involve recalculating the new digest with
+    # SHA256 and either moving or regenerating all ActiveStorage::Blob variants.
+    config.active_support.key_generator_hash_digest_class = OpenSSL::Digest::SHA1
+
     config.dictionary_host = ENV.fetch("NZSL_DICTIONARY_HOST", "https://nzsl.nz")
 
     config.upload_mode = if ENV.fetch("FEATURE_MULTIPLE_UPLOAD", "false").match?(/\Atrue|y/)


### PR DESCRIPTION
In Rails 7, the hash digest class was changed from SHA1 to SHA256, which means that our variant keys started generating with slightly different signatures. 

This change reverts the hash class to SHA1 so that our existing encoded videos keep a stable signed ID and continue to work without being re-encoded.

There's probably not a good case for figuring out how to update to SHA256, other than that we've now diverged from the Rails 7 framework default, and other similar changes in the future could break in the same way. We would probably have to refactor `CachedVideoTranscoder` to use ActiveStorage less deeply, in the hope that we wouldn't need to care about the key to this level.