### PR TITLE
NZSL-134 Addressed requests page design feedback

### DIFF
--- a/app/frontend/components/_home-main.scss
+++ b/app/frontend/components/_home-main.scss
@@ -7,14 +7,13 @@
   }
 
   &__icon {
-    margin-bottom: 24px;
+    margin-bottom: 8px;
     position: relative;
   }
 
   &__icon-shadow {
-    left: 20px;
+    left: 12px;
     position: absolute;
-    top: 20px;
     z-index: -1;
   }
 

--- a/app/frontend/components/_sign-requests.scss
+++ b/app/frontend/components/_sign-requests.scss
@@ -1,5 +1,5 @@
 .sign-requests{
-  &__footer-text {
+  &__facebook-text {
     margin: 1rem 0;
 
     @include breakpoint(large up) {

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -5,18 +5,9 @@
       <%= inline_svg_pack_tag "media/images/home/folder.svg", aria_hidden: true %>
       <%= inline_svg_pack_tag "media/images/home/rectangle.svg", aria_hidden: true, class: "home-main__icon-shadow" %>
     </div>
-    <h6>Save favourites</h6>
-    <p>Create folders and save your favourite signs</p>
+    <h6>Upload and save favourites</h6>
+    <p>Upload your recorded signs, keep them in your private folder and share links with others. </p>
     <%= link_to "Join NZSL Share", new_user_registration_path %>
-  </div>
-
-  <div class="home-main__container cell small-6 medium-3">
-    <div class="home-main__icon">
-      <%= inline_svg_pack_tag "media/images/home/camera-2.svg", aria_hidden: true %>
-      <%= inline_svg_pack_tag "media/images/home/rectangle.svg", aria_hidden: true, class: "home-main__icon-shadow" %>
-    </div>
-    <h6>Upload signs</h6>
-    <p>Upload your recorded signs, keep them in your private folder and share links with others</p>
   </div>
 
   <div class="home-main__container cell small-6 medium-3">
@@ -32,6 +23,15 @@
   <div class="home-main__container cell small-6 medium-3">
     <div class="home-main__icon">
       <%= inline_svg_pack_tag "media/images/home/upload.svg", aria_hidden: true %>
+      <%= inline_svg_pack_tag "media/images/home/rectangle.svg", aria_hidden: true, class: "home-main__icon-shadow" %>
+    </div>
+    <h6>Post public signs</h6>
+    <p>Approved member can add new signs for everyone to see</p>
+  </div>
+
+  <div class="home-main__container cell small-6 medium-3">
+    <div class="home-main__icon">
+      <%= inline_svg_pack_tag "media/images/home/camera-2.svg", aria_hidden: true %>
       <%= inline_svg_pack_tag "media/images/home/rectangle.svg", aria_hidden: true, class: "home-main__icon-shadow" %>
     </div>
     <h6>Request signs</h6>

--- a/app/views/sign_requests/index.html.erb
+++ b/app/views/sign_requests/index.html.erb
@@ -8,6 +8,28 @@
 
     <hr class="form__divider">
 
+    <div class="padding-2 grid-x">
+      <div class="cell small-12 large-shrink">
+        <%= inline_svg_pack_tag "media/images/facebook-light.svg", aria: true, title: "Facebook Logo" %>
+      </div>
+
+      <div class="cell small-12 large-auto sign-requests__facebook-text">
+        <small>
+          We are still developing the Request a Sign section. For now, you can place a request on our Facebook group:
+          NZSL Share – requests. Warning: this link will take you out of the NZSL Share page.
+        </small>
+      </div>
+
+      <div class="cell small-12 large-shrink">
+        <%= link_to SignRequestsPageContent.facebook_requests_url, class: "button--with-icon primary width-100 align-center" do %>
+          Go to Facebook
+          <%= inline_svg_pack_tag "media/images/chevron-right.svg", aria_hidden: true, class: "padding-left-1" %>
+        <% end %>
+      </div>
+    </div>
+
+    <hr class="form__divider">
+
     <div class="cell padding-2 large-9">
       <h2>Overview</h2>
 
@@ -48,28 +70,6 @@
         concept yet – but keep checking! As more Deaf signers start to discuss a concept, signs will
         emerge.
       </p>
-    </div>
-
-    <hr class="form__divider">
-
-    <div class="padding-2 grid-x">
-      <div class="cell small-12 large-shrink">
-        <%= inline_svg_pack_tag "media/images/facebook-light.svg", aria: true, title: "Facebook Logo" %>
-      </div>
-
-      <div class="cell small-12 large-auto sign-requests__footer-text">
-        <small>
-          We are still developing the Request a Sign section. For now, you can place a request on our Facebook group:
-          NZSL Share – requests. Warning: this link will take you out of the NZSL Share page.
-        </small>
-      </div>
-
-      <div class="cell small-12 large-shrink">
-        <%= link_to SignRequestsPageContent.facebook_requests_url, class: "button--with-icon primary width-100 align-center" do %>
-          Go to Facebook
-          <%= inline_svg_pack_tag "media/images/chevron-right.svg", aria_hidden: true, class: "padding-left-1" %>
-        <% end %>
-      </div>
     </div>
   </div>
 </div>

--- a/app/views/sign_requests/index.html.erb
+++ b/app/views/sign_requests/index.html.erb
@@ -31,15 +31,13 @@
     <hr class="form__divider">
 
     <div class="cell padding-2 large-9">
-      <h2>Overview</h2>
+      <div class="video-wrapper" "data-overlay">
+        <%= video_tag(SignRequestsPageContent.sign_requests_video_sources, class: "video has-video") %>
 
-      <div class="margin-vertical-1">
-        <div class="video-wrapper" "data-overlay">
-          <%= video_tag(SignRequestsPageContent.sign_requests_video_sources, class: "video has-video") %>
-
-          <i class="video__overlay" alt="Play video" ></i>
-        </div>
+        <i class="video__overlay" alt="Play video" ></i>
       </div>
+
+      <h2 class="margin-vertical-1">Overview</h2>
 
       <p>
         NZSL is growing and changing all the time. If you can’t find a sign, you can place a request


### PR DESCRIPTION
This PR addresses two pieces of feedback on the sign requests page and the home page

1. Update the links on the homepage to match updated designs
2. Update the requests page to move the footer into the header

![Screenshot 2023-03-27 125817](https://user-images.githubusercontent.com/18455252/227813060-87bf0014-c28d-4877-9807-0a44ce9269ee.png)
![Screenshot 2023-03-27 125752](https://user-images.githubusercontent.com/18455252/227813062-81a07130-7ce7-4a8b-a1a0-864e717965ba.png)
![Screenshot 2023-03-27 132303](https://user-images.githubusercontent.com/18455252/227814555-460f4ae6-fcf6-4b89-9847-fd0a2c23a74a.png)
