### PR TITLE
Require sign videos to be processed before we show the video OR thumbnails

### DIFF
--- a/app/presenters/sign_presenter.rb
+++ b/app/presenters/sign_presenter.rb
@@ -58,7 +58,7 @@ class SignPresenter < ApplicationPresenter # rubocop:disable Metrics/ClassLength
   # key is what pushes it over - 15.17 / 15 - and a descriptive cache
   # key is preferred to AbcSize compliance here
   def poster_url(size: 1080) # rubocop:disable Metrics/AbcSize
-    return fallback_poster_url unless sign.processed_thumbnails?
+    return fallback_poster_url unless sign.processed_thumbnails? && sign.processed_videos?
 
     preset = ThumbnailPreset.default.public_send("scale_#{size}").to_h
     preview = video.preview(preset)

--- a/spec/presenters/sign_presenter_spec.rb
+++ b/spec/presenters/sign_presenter_spec.rb
@@ -154,8 +154,16 @@ RSpec.describe SignPresenter, type: :presenter do
       end
     end
 
-    context "thumbnails are processed" do
-      before { sign.processed_thumbnails = true }
+    context "videos are not processed" do
+      before { sign.assign_attributes(processed_thumbnails: true, processed_videos: false) }
+
+      it "returns a placeholder" do
+        expect(presenter.poster_url).to match(/processing-[a-f0-9]+.svg\Z/)
+      end
+    end
+
+    context "thumbnails and videos are processed" do
+      before { sign.assign_attributes(processed_thumbnails: true, processed_videos: true) }
 
       it "requests a video preview with the default size" do
         preview = double.as_null_object

--- a/spec/system/edit_sign_feature_spec.rb
+++ b/spec/system/edit_sign_feature_spec.rb
@@ -146,11 +146,11 @@ RSpec.describe "Editing a sign", type: :system do
       it { expect(page).to have_selector ".video[poster*=processing]" }
     end
 
-    context "when the sign video has had thumbnails generated" do
+    context "when the sign video has had only thumbnails generated" do
       it "displays the processed thumbnail" do
         sign.update!(processed_thumbnails: true)
         visit sign_path(sign)
-        expect(page).to have_selector(".video[poster*='/rails/active_storage/']")
+        expect(page).to have_selector ".video[poster*=processing]"
       end
     end
 

--- a/spec/system/sign_show_page_spec.rb
+++ b/spec/system/sign_show_page_spec.rb
@@ -129,7 +129,7 @@ RSpec.describe "Sign show page", system: true do
 
     context "sign has thumbnails processed, but not videos" do
       let(:sign) { FactoryBot.create(:sign, :unprocessed, :processed_thumbnails, contributor: user) }
-      it { expect(subject[:poster]).to match(%r{/rails/active_storage}) }
+      it { expect(subject[:poster]).to match(/processing-[a-f0-9]+.svg/) }
     end
 
     context "sign has videos" do


### PR DESCRIPTION
We've experienced some problems with sign videos being unplayable, because while thumbnails have generated, the sign video has not (or it has, but we have not received the callback so have not updated the `processed_videos` flag on the Sign.

This pull request tightens the critieria for us showing the video poster to require the videos to be processed. This will surface signs that don't have playable videos more easily, allowing us to see these easily and try and track down _why_ they are not processed. Currently, it's quite hard to discover broken signs otherwise, since it requires someone to click the video and see that it does not play - the doing of which queues a video transcode for the missing video, and 'fixes' the sign (even though it is still not fully processed).

