### PR TITLE
Follow Sidekiq's concurrency recommendation for running on 1x dynos on Heroku

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,3 @@
 web:     bundle exec puma -C config/puma.rb
-worker:  bundle exec sidekiq -C config/sidekiq.yml
+worker:  bundle exec sidekiq -c 5 -C config/sidekiq.yml
 release: bundle exec rake dictionary:update && bundle exec rake db:migrate db:seed


### PR DESCRIPTION
Excerpts:

- WARNING: don't ever use a concurrency value greater than 10 without thorough testing.
- I don't recommend setting Sidekiq's concurrency greater than 10. At larger values, you will see poor performance due to CPU contention. With 1x and 2x dynos, I would set concurrency to 5.

From https://github.com/sidekiq/sidekiq/wiki/Heroku

It's possible that we need to optimise how we download and process videos, however reducing the concurrency from the default value of 25 should help.