### PR TITLE
Improve behaviour of aspect ratios when presenting videos

### DIFF
--- a/app/frontend/components/_sign-card.scss
+++ b/app/frontend/components/_sign-card.scss
@@ -27,7 +27,10 @@
   }
 
   &--official {
-    .sign-card__media { background: #000; }
+    .sign-card__media {
+      @include responsive-embed(dictionary);
+      background: #000;
+    }
     .sign-card__title { color: $black; }
     h3 { margin-bottom: 0.25rem; }
 

--- a/app/frontend/components/uppy-file-upload.js
+++ b/app/frontend/components/uppy-file-upload.js
@@ -22,6 +22,11 @@ const uppyFileUpload = (container, options = {}) => {
   uppy.use(Webcam,  {
     modes: "video-only",
     countdown: true,
+    videoConstraints: {
+      aspectRatio: {
+        ideal:  1.7777777778 // 16x9
+      }
+    },
     locale: {
       strings: {
         pluginNameCamera: "Video recording",

--- a/app/frontend/foundation/_settings.scss
+++ b/app/frontend/foundation/_settings.scss
@@ -729,7 +729,8 @@ $prototype-text-overflow: ellipsis;
 
 $responsive-embed-margin-bottom: rem-calc(16);
 $responsive-embed-ratios: (
-  default: 16 by 9
+  default: 16 by 9,
+  dictionary: 4 by 3,
 );
 
 // 47. Reveal

--- a/config/application.rb
+++ b/config/application.rb
@@ -49,7 +49,7 @@ module NzslShare
 
     config.dictionary_host = ENV.fetch("NZSL_DICTIONARY_HOST", "https://nzsl.nz")
 
-    config.upload_mode = if ENV.fetch("FEATURE_MULTIPLE_UPLOAD", "false").match?(/\Atrue|y/)
+    config.upload_mode = if ENV.fetch("FEATURE_MULTIPLE_UPLOAD", "true").match?(/\Atrue|y/)
                            :uppy
                          else
                            :legacy

--- a/spec/system/edit_sign_illustrations_spec.rb
+++ b/spec/system/edit_sign_illustrations_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe "Edit sign illustrations", type: :system do
     expect(page).to have_selector(".sign-illustrations > *", count: 3)
   end
 
-  it "can specify illustrations for a sign without javascript", uses_javacript: false do
+  it "can specify illustrations for a sign without javascript", uses_javacript: false, upload_mode: :legacy do
     within(".illustrations") { choose_file Rails.root.join("spec/fixtures/image.png") }
     click_on "Update Sign"
     expect(page).to have_content I18n.t("signs.update.success")

--- a/spec/system/edit_sign_usage_examples_spec.rb
+++ b/spec/system/edit_sign_usage_examples_spec.rb
@@ -130,7 +130,7 @@ RSpec.describe "Editing sign usage examples", type: :system do
     expect(page).to have_selector(".sign-usage-examples > *", count: 2)
   end
 
-  it "can specify usage examples for a sign without javascript", uses_javacript: false do
+  it "can specify usage examples for a sign without javascript", uses_javacript: false, upload_mode: :legacy do
     within(".usage-examples") { choose_file }
     click_on "Update Sign"
     expect(page).to have_content I18n.t("signs.update.success")


### PR DESCRIPTION
This pull request makes some simple improvements to how videos are presented in NZSL Share:

1. If we are displaying an official dictionary sign, display this in 4x3 ratio, not 16x9 - the dictionary videos are mostly (not 100% exclusively) 4x3, so using this aspect ratio in Share prevents black bars on these videos to force them to 16x9, and also means that they are slightly larger so easier to see.
2. Uppy allows us to specify media track constraints when recording a video, one of which is our preferred aspect ratio. I've set this to 16x9, since this is the display aspect ratio for NZSL Share. I'm hoping this will resolve some device-specific issues we've encountered where, without a constraint specified, a video will be recorded in 4:3 even if the camera hardware supports 16:9. This is just a preference, and ultimately the hardware or user agent can give us something different.
3. Uppy is now the default way to upload signs in all environments, so to prevent confusion, it now defaults to on, rather than defaulting to off. This should make it easier for devs trying to recreate issues to follow the same steps to reproduce.
