### PR TITLE
Ignore postcss 7 vuln (GHSA-7fh5-64p2-3v2j)

### DIFF
--- a/.osv-detector.yml
+++ b/.osv-detector.yml
@@ -8,3 +8,4 @@ ignore:
   - GHSA-w5p7-h5w8-2hfq
   - GHSA-ww39-953v-wcq6
   - GHSA-x4jg-mjrx-434g
+  - GHSA-7fh5-64p2-3v2j


### PR DESCRIPTION
This PR ignores the vulnerability in postcss 7 as we are not currently able to upgrade it to postcss 8 in order to fix this. The ignored vulnerability can be found here - [GHSA-7fh5-64p2-3v2j](https://github.com/advisories/GHSA-7fh5-64p2-3v2j)