### PR TITLE
NZSL-73 Added extra content to signbank export

### DIFF
--- a/app/services/signbank_export.rb
+++ b/app/services/signbank_export.rb
@@ -10,22 +10,33 @@ class SignbankExport
       signs.secondary,
       signs.description,
       signs.notes,
-      array_to_string(array_agg(DISTINCT topics.name), '#{SEPARATOR}') AS topic_names,
-      array_to_string(array_agg(DISTINCT videos.id), '#{SEPARATOR}') AS videos,
-      array_to_string(array_agg(DISTINCT illustrations.id), '#{SEPARATOR}') AS illustrations,
-      array_to_string(array_agg(DISTINCT usage_examples.id), '#{SEPARATOR}') AS usage_examples
+      signs.created_at,
+      contributors.email AS contributor_email,
+      contributors.username AS contributor_username,
+      COUNT(DISTINCT agrees.id) AS agrees,
+      COUNT(DISTINCT disagrees.id) AS disagrees,
+      ARRAY_TO_STRING(ARRAY_AGG(DISTINCT topics.name), '#{SEPARATOR}') AS topic_names,
+      ARRAY_TO_STRING(ARRAY_AGG(DISTINCT videos.id), '#{SEPARATOR}') AS videos,
+      ARRAY_TO_STRING(ARRAY_AGG(DISTINCT illustrations.id), '#{SEPARATOR}') AS illustrations,
+      ARRAY_TO_STRING(ARRAY_AGG(DISTINCT usage_examples.id), '#{SEPARATOR}') AS usage_examples,
+      ARRAY_TO_STRING(ARRAY_AGG(DISTINCT CONCAT_WS(': ', sign_commenters.username, sign_comments.comment)), '#{SEPARATOR}') AS sign_comments
     FROM
       signs
       FULL OUTER JOIN sign_topics ON sign_topics.sign_id = signs.id
+      FULL OUTER JOIN users AS contributors ON contributors.id = signs.contributor_id
       FULL OUTER JOIN topics ON sign_topics.topic_id = topics.id
+      FULL OUTER JOIN sign_comments ON signs.id = sign_comments.sign_id
+      FULL OUTER JOIN users AS sign_commenters ON sign_comments.user_id = sign_commenters.id
       FULL OUTER JOIN active_storage_attachments ON active_storage_attachments.record_id = signs.id AND active_storage_attachments.record_type = 'Sign'
       FULL OUTER JOIN active_storage_blobs AS videos ON active_storage_attachments.blob_id = videos.id AND active_storage_attachments.name = 'video'
       FULL OUTER JOIN active_storage_blobs AS illustrations ON active_storage_attachments.blob_id = illustrations.id AND active_storage_attachments.name = 'illustrations'
       FULL OUTER JOIN active_storage_blobs AS usage_examples ON active_storage_attachments.blob_id = usage_examples.id AND active_storage_attachments.name = 'usage_examples'
+      FULL OUTER JOIN sign_activities AS agrees ON signs.id = agrees.sign_id and agrees.key like 'agree'
+      FULL OUTER JOIN sign_activities AS disagrees on signs.id = disagrees.sign_id and disagrees.key like 'disagree'
     WHERE
       status = 'published'
     GROUP BY
-      signs.id
+      signs.id, contributors.email, contributors.username
     ORDER BY
       signs.id ASC;
   SQL

--- a/app/services/signbank_export.rb
+++ b/app/services/signbank_export.rb
@@ -30,7 +30,7 @@ class SignbankExport
       FULL OUTER JOIN sign_topics ON sign_topics.sign_id = signs.id
       FULL OUTER JOIN users AS contributors ON contributors.id = signs.contributor_id
       FULL OUTER JOIN topics ON sign_topics.topic_id = topics.id
-      FULL OUTER JOIN sign_comments ON signs.id = sign_comments.sign_id AND sign_comments.removed = false AND sign_comments.display = true
+      FULL OUTER JOIN sign_comments ON signs.id = sign_comments.sign_id AND sign_comments.removed = false AND sign_comments.display = true AND sign_comments.folder_id IS NULL
       FULL OUTER JOIN users AS sign_commenters ON sign_comments.user_id = sign_commenters.id
       FULL OUTER JOIN active_storage_attachments ON active_storage_attachments.record_id = signs.id AND active_storage_attachments.record_type = 'Sign'
       FULL OUTER JOIN active_storage_blobs AS videos ON active_storage_attachments.blob_id = videos.id AND active_storage_attachments.name = 'video'

--- a/spec/factories/sign.rb
+++ b/spec/factories/sign.rb
@@ -88,9 +88,5 @@ FactoryBot.define do
       description { Faker::Lorem.sentence }
       notes { Faker::Lorem.paragraph }
     end
-
-    trait :with_sign_activities do
-      activities { FactoryBot.create_list(:sign_activity, 5) }
-    end
   end
 end

--- a/spec/factories/sign.rb
+++ b/spec/factories/sign.rb
@@ -92,9 +92,5 @@ FactoryBot.define do
     trait :with_sign_activities do
       activities { FactoryBot.create_list(:sign_activity, 5) }
     end
-
-    trait :with_sign_comments do
-      sign_comments { FactoryBot.create_list(:sign_comment, 2) }
-    end
   end
 end

--- a/spec/factories/sign.rb
+++ b/spec/factories/sign.rb
@@ -88,5 +88,13 @@ FactoryBot.define do
       description { Faker::Lorem.sentence }
       notes { Faker::Lorem.paragraph }
     end
+
+    trait :with_sign_activities do
+      activities { FactoryBot.create_list(:sign_activity, 5) }
+    end
+
+    trait :with_sign_comments do
+      sign_comments { FactoryBot.create_list(:sign_comment, 2) }
+    end
   end
 end

--- a/spec/services/signbank_export_spec.rb
+++ b/spec/services/signbank_export_spec.rb
@@ -118,14 +118,14 @@ class SignbankExportWorld
 
   def setup
     @published_signs = FactoryBot.create_list(
-      :sign, 2, :published, :processed, :with_illustrations, :with_usage_examples,
-      :with_additional_info, :with_sign_activities
+      :sign, 2, :published, :processed, :with_illustrations, :with_usage_examples, :with_additional_info
     )
     @unpublished_sign = FactoryBot.create(:sign)
     @published_comment = FactoryBot.create(:sign_comment, sign: @published_signs.second)
     @deleted_comment = FactoryBot.create(:sign_comment, sign: @published_signs.second, removed: true)
     @invisible_comment = FactoryBot.create(:sign_comment, sign: @published_signs.second, display: false)
     @anonymous_comment = FactoryBot.create(:sign_comment, sign: @published_signs.second, anonymous: true)
+    FactoryBot.create_list(:sign_activity, 5, sign: @published_signs.second)
 
     self
   end


### PR DESCRIPTION
This PR adds more info to the signbank export based on Micky's comments on NZSL-75. This includes the following:

- Contributer username
- Contributer email address
- Time of sign upload
- Agree and disagree counts
- Comments (including both the username and the comment itself)

Here is Micky's table

![image-20231203-215146](https://github.com/ackama/nzsl-share/assets/18455252/0e52a4ee-e613-4316-bb50-2aa8dcc35837)
