### PR TITLE
NZSL-160: Pull Signbank dictionary database from a public or private S3 location

### DIFF
--- a/config/initializers/dictionary_sign.rb
+++ b/config/initializers/dictionary_sign.rb
@@ -2,12 +2,11 @@ Rails.application.reloader.to_prepare do
   # Update the dictionary file on boot
   Rails.application.load_tasks
 
-  # begin
-  #   Rake::Task["dictionary:update"].execute
-  # rescue StandardError => e
-  #   warn e
-  # end
-  Rake::Task["dictionary:update"].execute
+  begin
+    Rake::Task["dictionary:update"].execute
+  rescue StandardError => e
+    warn e
+  end
 
   ##
   # All other tables make heavy use of a 'word' column. Add an alias for it here so that

--- a/config/initializers/dictionary_sign.rb
+++ b/config/initializers/dictionary_sign.rb
@@ -1,8 +1,12 @@
 Rails.application.reloader.to_prepare do
-  # Update the dictionary file if it is older than 1 month
-  path = Rails.root.join("db/nzsl-dictionary.db.sqlite3")
+  # Update the dictionary file on boot
   Rails.application.load_tasks
-  Rake::Task["dictionary:update"].execute if !path.exist? || path.mtime <= 1.month.ago
+
+  begin
+    Rake::Task["dictionary:update"].execute
+  rescue StandardError => e
+    warn e
+  end
 
   ##
   # All other tables make heavy use of a 'word' column. Add an alias for it here so that

--- a/config/initializers/dictionary_sign.rb
+++ b/config/initializers/dictionary_sign.rb
@@ -2,11 +2,12 @@ Rails.application.reloader.to_prepare do
   # Update the dictionary file on boot
   Rails.application.load_tasks
 
-  begin
-    Rake::Task["dictionary:update"].execute
-  rescue StandardError => e
-    warn e
-  end
+  # begin
+  #   Rake::Task["dictionary:update"].execute
+  # rescue StandardError => e
+  #   warn e
+  # end
+  Rake::Task["dictionary:update"].execute
 
   ##
   # All other tables make heavy use of a 'word' column. Add an alias for it here so that

--- a/example.env
+++ b/example.env
@@ -11,3 +11,6 @@ SIDEKIQ_WEB_PASSWORD=password
 MAIL_FROM=development@example.com
 CONTACT_EMAIL=development@example.com
 PORT=3000
+
+# The latest public release
+DICTIONARY_DATABASE_S3_LOCATION="s3://nzsl-signbank-media-production/dictionary-exports/nzsl.db"

--- a/example.env
+++ b/example.env
@@ -11,6 +11,7 @@ SIDEKIQ_WEB_PASSWORD=password
 MAIL_FROM=development@example.com
 CONTACT_EMAIL=development@example.com
 PORT=3000
+AWS_REGION="ap-southeast-2"
 
 # The latest public release
 DICTIONARY_DATABASE_S3_LOCATION="s3://nzsl-signbank-media-production/dictionary-exports/nzsl.db"

--- a/lib/tasks/dictionary.rake
+++ b/lib/tasks/dictionary.rake
@@ -21,8 +21,7 @@ namespace :dictionary do
   end
 
   def s3_client(region:, access_key_id: nil, secret_access_key: nil)
-    opts = { region:, credentials: nil }
-    opts[:credentials] = Aws::Credentials.new(access_key_id, secret_access_key) if access_key_id && secret_access_key
+    opts = { region:, access_key_id:, secret_access_key: }.compact_blank
 
     Aws::S3::Client.new(opts)
   end

--- a/lib/tasks/dictionary.rake
+++ b/lib/tasks/dictionary.rake
@@ -21,7 +21,7 @@ namespace :dictionary do
   end
 
   def s3_client(region:, access_key_id: nil, secret_access_key: nil)
-    opts = { region: }
+    opts = { region:, credentials: nil }
     opts[:credentials] = Aws::Credentials.new(access_key_id, secret_access_key) if access_key_id && secret_access_key
 
     Aws::S3::Client.new(opts)

--- a/lib/tasks/dictionary.rake
+++ b/lib/tasks/dictionary.rake
@@ -1,32 +1,54 @@
 namespace :dictionary do
   desc "Updates the NZSL dictionary packaged with the application to the latest release from Signbank"
   task :update do # rubocop:disable Rails/RakeEnvironment - we need to place this file before the app can start
-    repo = "odnzsl/nzsl-dictionary-scripts"
-    filename = "nzsl.db"
-    content_type = "application/vnd.sqlite3"
-    release_uri = URI::HTTPS.build(host: "api.github.com", path: "/repos/#{repo}/releases/latest")
-    release = {}
+    database_s3_location = URI.parse(ENV.fetch("DICTIONARY_DATABASE_S3_LOCATION") || "")
+    client = s3_client(region: ENV.fetch("DICTIONARY_AWS_REGION", ENV.fetch("AWS_REGION", nil)),
+                       access_key_id: ENV.fetch("DICTIONARY_AWS_ACCESS_KEY_ID", nil),
+                       secret_access_key: ENV.fetch("DICTIONARY_AWS_SECRET_ACCESS_KEY", nil))
 
-    begin
-      release = JSON.parse(release_uri.open.read)
-    rescue OpenURI::HTTPError => e
-      puts "Failed to access release, retrying after 10s... (#{e})"
-      sleep 10
-      retry
-    end
+    fail "DICTIONARY_DATABASE_S3_LOCATION must be an S3 URI" unless database_s3_location.scheme == "s3"
 
-    database_asset = release["assets"].find do |asset|
-      asset["name"] == filename && asset["content_type"] == content_type
-    end
-
-    database_url = database_asset.fetch("browser_download_url")
-    File.binwrite("db/new-dictionary.sqlite3", URI.parse(database_url).open.read)
+    download_s3_uri(database_s3_location, "db/new-dictionary.sqlite3", client:)
 
     database = SQLite3::Database.open("db/new-dictionary.sqlite3")
     fail "Database does not pass integrity check" unless database.integrity_check == [["ok"]]
 
+    version = database.get_int_pragma("user_version")
+
     FileUtils.mv("db/new-dictionary.sqlite3", "db/nzsl-dictionary.db.sqlite3")
 
-    puts "Updated db/nzsl-dictionary.db.sqlite3 to #{release["name"]}"
+    puts "Updated db/nzsl-dictionary.db.sqlite3 to #{version}"
+  end
+
+  def s3_client(region:, access_key_id: nil, secret_access_key: nil)
+    opts = { region: }
+    opts[:credentials] = Aws::Credentials.new(access_key_id, secret_access_key) if access_key_id && secret_access_key
+
+    Aws::S3::Client.new(opts)
+  end
+
+  def download_uri(uri, target_path)
+    uri = URI.parse(uri) unless uri.is_a?(URI)
+
+    Net::HTTP.start(uri.host, uri.port, use_ssl: true) do |http|
+      response = http.get(uri.request_uri).tap(&:value)
+      File.binwrite(target_path, response.body)
+    end
+  end
+
+  def download_s3_uri(s3_uri, target_path, client:)
+    s3_object = Aws::S3::Object.new(s3_uri.host, s3_uri.path[1..], client:)
+    uris_to_try = [s3_object.public_url, s3_object.presigned_url(:get, expires_in: 60)]
+
+    downloaded_uri = uris_to_try.detect do |uri|
+      download_uri(uri, target_path)
+      true
+    rescue Net::HTTPClientException => e
+      next if e.message == "403 \"Forbidden\""
+
+      raise "Failed to download #{s3_uri}: #{e}"
+    end
+
+    fail "Failed to download #{s3_uri}: All URIs have been tried" unless downloaded_uri
   end
 end

--- a/lib/tasks/dictionary.rake
+++ b/lib/tasks/dictionary.rake
@@ -41,6 +41,7 @@ namespace :dictionary do
     uris_to_try = [s3_object.public_url, s3_object.presigned_url(:get, expires_in: 60)]
 
     downloaded_uri = uris_to_try.detect do |uri|
+      puts "Downloading #{uri}"
       download_uri(uri, target_path)
       true
     rescue Net::HTTPClientException => e


### PR DESCRIPTION
This pull request modifies the boot process of NZSL Share to download a file from a specified S3 location. This can be a public or private S3 object, and the URI is specified using an environment variable. We attempt to download from the public location first, then attempt to generate a presigned URL and download from that. If no keypair is present and the public URL is not accessible (e.g. this is a prerelease database), then the app continues to boot, but without a dictionary database. 

I'm expecting to provide a similar patch to https://github.com/odnzsl/nzsl-online. We might consider extracting this common code into a Rubygem at some point, since we fairly regularly end up duplicating code. 