### PR TITLE
NZSL-163: Display the dictionary database version in the application footer

### DIFF
--- a/app/models/dictionary_sign.rb
+++ b/app/models/dictionary_sign.rb
@@ -21,4 +21,8 @@ class DictionarySign < ApplicationRecord
   # Use attributes for common sign elements to match the NZSL Share sign schema
   alias_attribute :word, :gloss
   alias_attribute :secondary, :minor
+
+  def self.version
+    @version ||= connection.execute("PRAGMA user_version").first["user_version"]
+  end
 end

--- a/app/views/application/_footer.html.erb
+++ b/app/views/application/_footer.html.erb
@@ -55,6 +55,7 @@
           This is an Open Source project.
         <%end%>
         </li>
+
       </ul>
     </div>
   </div>
@@ -62,6 +63,9 @@
     <div class="footer__license__content grid-x">
       <div class="cell auto">
         <p>
+           <% if DictionarySign.version %>
+            Dictionary database version: <%= DictionarySign.version %><br>
+          <% end %>
           <%= link_to "© Deaf Studies Research Unit, Victoria University of Wellington", "https://www.victoria.ac.nz/lals/centres-and-institutes/dsru",  target: "_blank" %>
         </p>
       </div>

--- a/spec/views/application/_footer.html.erb_spec.rb
+++ b/spec/views/application/_footer.html.erb_spec.rb
@@ -1,0 +1,9 @@
+require "rails_helper"
+
+RSpec.describe "application/_footer.html.erb", type: :view do
+  it "displays the DictionarySign version in the footer" do
+    allow(DictionarySign).to receive(:version).and_return(20_230_101)
+    render
+    expect(rendered).to have_content "Dictionary database version: 20230101"
+  end
+end

--- a/spec/views/application/_footer.html.erb_spec.rb
+++ b/spec/views/application/_footer.html.erb_spec.rb
@@ -6,4 +6,10 @@ RSpec.describe "application/_footer.html.erb", type: :view do
     render
     expect(rendered).to have_content "Dictionary database version: 20230101"
   end
+
+  it "does not display the DictionarySign version text in the footer when the version is missing" do
+    allow(DictionarySign).to receive(:version).and_return(nil)
+    render
+    expect(rendered).not_to have_content "Dictionary database version"
+  end
 end


### PR DESCRIPTION
This pull request adjusts the footer to display the user_version PRAGMA value from the released dictionary database. This allows users to see what version of the data is being used. This is especially handy to check that the data has been updated, and to check what version of data is used if an issue is noticed.

![image](https://github.com/ackama/nzsl-share/assets/292020/7dbce08a-da3e-4ff9-90d5-129c708f8cf9)
