### PR TITLE
Remove footer cache without any expiring key fragments

### DIFF
--- a/app/views/application/_footer.html.erb
+++ b/app/views/application/_footer.html.erb
@@ -1,5 +1,4 @@
 
-<% cache do %>
 <footer class="footer">
 <div class="grid-container">
   <div class="grid-x margin-bottom-3 margin-top-2 align-middle">
@@ -78,4 +77,3 @@
   </div>
   </div>
 </footer>
-<% end %>


### PR DESCRIPTION
I added this several years ago, I now disagree with myself. Caching the template without any key parts to expire doesn't really add a lot. Template rendering of a largely static template should be just as fast or faster than retrieving from a cache, and specifically this stops the database version from showing the correct value.
