### PR TITLE
Increase guard clause to also bail out when the video URI is an empty string

### DIFF
--- a/app/models/dictionary_sign.rb
+++ b/app/models/dictionary_sign.rb
@@ -23,7 +23,7 @@ class DictionarySign < ApplicationRecord
   alias_attribute :secondary, :minor
 
   def video
-    return unless super
+    return unless super.presence
 
     DictionarySignAsset.new(super).url
   end

--- a/spec/models/dictionary_sign_spec.rb
+++ b/spec/models/dictionary_sign_spec.rb
@@ -9,6 +9,16 @@ RSpec.describe DictionarySign, type: :model do
     expect(described_class.connection.adapter_name).to eq "SQLite"
   end
 
+  it "wraps the video attribute with a value object" do
+    sign = FactoryBot.create(:dictionary_sign, video: "https://example.com/video.mp4", id: SecureRandom.uuid)
+    expect(sign.video).to eq URI.parse("https://example.com/video.mp4")
+  end
+
+  it "guards against a blank video attribute value" do
+    sign = FactoryBot.create(:dictionary_sign, video: "", id: SecureRandom.uuid)
+    expect(sign.video).to be_nil
+  end
+
   it "filters out obscene entries by default" do
     sign = FactoryBot.create(:dictionary_sign, usage: "obscene", id: SecureRandom.uuid)
     expect(DictionarySign.unscoped.where(id: sign.id)).to eq [sign]


### PR DESCRIPTION
Technically, all signs should have a main video. Due to prerelease exports though, data that we have previously assumed to be present can actually be missing, so the guard clause here needs to check for nil OR empty string.