### PR TITLE
Remove unused 'description' field from signs

### DIFF
--- a/app/services/signbank_export.rb
+++ b/app/services/signbank_export.rb
@@ -8,7 +8,6 @@ class SignbankExport
       signs.word,
       signs.maori,
       signs.secondary,
-      signs.description,
       signs.notes,
       signs.created_at,
       contributors.email AS contributor_email,

--- a/db/migrate/20240116022132_remove_description_from_signs.rb
+++ b/db/migrate/20240116022132_remove_description_from_signs.rb
@@ -1,0 +1,5 @@
+class RemoveDescriptionFromSigns < ActiveRecord::Migration[7.0]
+  def change
+    remove_column :signs, :description, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,8 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_02_07_021057) do
-
+ActiveRecord::Schema[7.0].define(version: 2024_01_16_022132) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "unaccent"
@@ -168,7 +167,6 @@ ActiveRecord::Schema.define(version: 2023_02_07_021057) do
     t.datetime "updated_at", null: false
     t.datetime "created_at", null: false
     t.bigint "contributor_id", null: false
-    t.text "description"
     t.text "notes"
     t.boolean "processed_videos", default: false, null: false
     t.boolean "processed_thumbnails", default: false, null: false

--- a/spec/factories/sign.rb
+++ b/spec/factories/sign.rb
@@ -85,7 +85,6 @@ FactoryBot.define do
     end
 
     trait :with_additional_info do
-      description { Faker::Lorem.sentence }
       notes { Faker::Lorem.paragraph }
     end
   end

--- a/spec/services/signbank_export_spec.rb
+++ b/spec/services/signbank_export_spec.rb
@@ -34,7 +34,6 @@ RSpec.describe SignbankExport, type: :service do
         word: sign.word,
         maori: sign.maori,
         secondary: sign.secondary,
-        description: sign.description,
         notes: sign.notes,
         topic_names: sign.topics.order(:id).pluck(:name).sort.join("|"),
         contributor_email: sign.contributor.email,
@@ -68,7 +67,7 @@ RSpec.describe SignbankExport, type: :service do
     it "builds the expected CSV structure" do
       lines = csv.split("\n")
       expect(lines.first).to eq(
-        "word,maori,secondary,description,notes,created_at,contributor_email,contributor_username,agrees," \
+        "word,maori,secondary,notes,created_at,contributor_email,contributor_username,agrees," \
         "disagrees,topic_names,videos,illustrations,usage_examples,sign_comments"
       )
       expect(lines.size).to eq 3 # Headers plus 2 included signs


### PR DESCRIPTION
This field was included in the signbank export, which is how we noticed it was still there. It appears that it was [added](https://github.com/ackama/nzsl-share/commit/87e78384725d024013acbec3e9a258fb7d0f1654) to an early data modelling commit, and subsequently superseded by notes and usage examples. It's not used in any view, dashboard, presenter or anywhere else that I can see, so to avoid confusion, should be removed.