### PR TITLE
refactor: avoid using `public_send` in attachments controller

### DIFF
--- a/app/controllers/sign_attachments_controller.rb
+++ b/app/controllers/sign_attachments_controller.rb
@@ -44,7 +44,15 @@ class SignAttachmentsController < ApplicationController
   end
 
   def attachments
-    sign.public_send(attachment_type)
+    case attachment_type
+    when "usage_examples"
+      sign.usage_examples
+    when "illustrations"
+      sign.illustrations
+    else
+      # we're constraining at the route level so this should never actually happen
+      fail NoMethodError, "#{attachment_type} is not supported"
+    end
   end
 
   def attachment_type


### PR DESCRIPTION
We have a constraint at the route level which means this isn't an actual vulnerability but it's still not nice to have in a controller so lets be explicit instead.

I've _not_ included any tests since this can't actually be triggered due to the routing constraint, but that should be fine since this will catch if the constraint ever changes.