### PR TITLE
chore: ignore `webpack-dev-middleware` advisory

### DIFF
--- a/.osv-detector.yml
+++ b/.osv-detector.yml
@@ -1,11 +1,12 @@
 ignore:
   - GHSA-2r2c-g63r-vccr
   - GHSA-5rrq-pxf6-6jx5
+  - GHSA-7fh5-64p2-3v2j
   - GHSA-8fr3-hfg3-gpgp
   - GHSA-cfm4-qjh2-4765
   - GHSA-gf8q-jrpm-jvxq
   - GHSA-rp65-9cf3-cjxr
   - GHSA-w5p7-h5w8-2hfq
+  - GHSA-wr3j-pwj9-hqq6
   - GHSA-ww39-953v-wcq6
   - GHSA-x4jg-mjrx-434g
-  - GHSA-7fh5-64p2-3v2j


### PR DESCRIPTION
Patching GHSA-wr3j-pwj9-hqq6 requires a major upgrade to webpacker/shakapacker which we're not ready to take on yet - we can ignore the advisory in the meantime as it is only being used for local development.