### PR TITLE
NZSL-186 Export ID with signbank export

### DIFF
--- a/app/services/signbank_export.rb
+++ b/app/services/signbank_export.rb
@@ -5,6 +5,7 @@ class SignbankExport
   SEPARATOR = "|".freeze
   QUERY = <<~SQL.squish.freeze
     SELECT
+      signs.id,
       signs.word,
       signs.maori,
       signs.secondary,

--- a/spec/services/signbank_export_spec.rb
+++ b/spec/services/signbank_export_spec.rb
@@ -28,6 +28,7 @@ RSpec.describe SignbankExport, type: :service do
       # Get last result and check fields
       result = results.last # ordered by ID asc
       expect(result).to include({
+        id: sign.id,
         videos: sign.video.blob.id.to_s,
         usage_examples: sign.usage_examples.blobs.pluck(:id).sort.join("|"),
         illustrations: sign.illustrations.blobs.pluck(:id).sort.join("|"),
@@ -67,7 +68,7 @@ RSpec.describe SignbankExport, type: :service do
     it "builds the expected CSV structure" do
       lines = csv.split("\n")
       expect(lines.first).to eq(
-        "word,maori,secondary,notes,created_at,contributor_email,contributor_username,agrees," \
+        "id,word,maori,secondary,notes,created_at,contributor_email,contributor_username,agrees," \
         "disagrees,topic_names,videos,illustrations,usage_examples,sign_comments"
       )
       expect(lines.size).to eq 3 # Headers plus 2 included signs


### PR DESCRIPTION
This PR adds sign ids to the signbank export. These are used by signbank to filter out signs that have already been imported. The PR that adds the filtering out of signs with matching ids is implemented in signbank here: https://github.com/ODNZSL/NZSL-signbank/pull/159

Here is a truncated sample export from the development environment
[signbank(14).csv](https://github.com/ackama/nzsl-share/files/14859555/signbank.14.csv)
