### PR TITLE
chore: ignore unpatchable ip vulnerability

### DIFF
--- a/.osv-detector.yml
+++ b/.osv-detector.yml
@@ -10,3 +10,4 @@ ignore:
   - GHSA-wr3j-pwj9-hqq6
   - GHSA-ww39-953v-wcq6
   - GHSA-x4jg-mjrx-434g
+  - GHSA-2p57-rm9w-gvfp


### PR DESCRIPTION
Currently there is no patch for the security advisory https://github.com/advisories/GHSA-2p57-rm9w-gvfp