### PR TITLE
ci: omit default brakeman flags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
           bundler-cache: true
 
       - name: Run Ruby static analysis
-        run: bundle exec brakeman --run-all-checks --exit-on-warn --format plain .
+        run: bundle exec brakeman --run-all-checks .
 
   eslint:
     runs-on: ubuntu-latest

--- a/bin/ci-test
+++ b/bin/ci-test
@@ -2,7 +2,7 @@
 set -e
 
 bundle exec bundle-audit --update --ignore CVE-2021-22904 CVE-2021-22902 CVE-2021-22885
-bundle exec brakeman --run-all-checks --exit-on-warn .
+bundle exec brakeman --run-all-checks .
 bin/lint-styles
 bin/js-lint
 


### PR DESCRIPTION
These are the default [since v4.0.0](https://github.com/presidentbeef/brakeman/blob/main/CHANGES.md#400---2017-09-25).

The actual motivator for this is that it brings the line under 80 characters so Prettier is happier, but also really we should be using `config/brakeman.yml` for these settings to ensure all brakeman calls are consistent by default (I've not added that though because I have not seen evidence that brakeman is in the habit of changing its defaults often, so I don't think we need to worry)

Also see https://github.com/ackama/rails-template/pull/521