### PR TITLE
chore: don't try to re-download the database on every reload

### DIFF
--- a/config/initializers/dictionary_sign.rb
+++ b/config/initializers/dictionary_sign.rb
@@ -1,9 +1,15 @@
 Rails.application.reloader.to_prepare do
+  path = Rails.root.join("db/nzsl-dictionary.db.sqlite3")
+
   # Update the dictionary file on boot
   Rails.application.load_tasks
 
   begin
-    Rake::Task["dictionary:update"].execute
+    if !path.exist? || path.mtime <= 1.month.ago
+      Rake::Task["dictionary:update"].execute
+    else
+      warn "Dictionary file is up to date"
+    end
   rescue StandardError => e
     warn e
   end


### PR DESCRIPTION
Downloading the database blocks all other actions including consuming exit signals and is compounded by seemingly being able to get triggered multiple times in quick succession even though the reloader only seems to get called once - I think what happens is that after making a change reloading the page triggers a reload cycle for every request and thus multiple sequential database downloads?

Ultimately we can avoid slowing down local development by only (re)downloading the database if its more than a month old or does not exist which ironically matches the behaviour currently described in the readme anyway