### PR TITLE
fix: use a valid javascript regexp for username validation

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,6 +2,7 @@ class User < ApplicationRecord
   include AASM
 
   USERNAME_REGEXP = /\A[a-zA-Z0-9_.]+\Z/
+  USERNAME_JS_REGEXP = USERNAME_REGEXP.source.gsub("\\A", "^").gsub("\\Z", "$")
   PERMITTED_IMAGE_CONTENT_TYPE_REGEXP = %r{\Aimage/.+\Z}
   MAXIMUM_FILE_SIZE = 250.megabytes
 

--- a/app/views/users/registrations/edit.html.erb
+++ b/app/views/users/registrations/edit.html.erb
@@ -18,7 +18,7 @@
       <% end %>
 
       <%= f.label :username %>
-      <%= f.text_field :username,pattern: User::USERNAME_REGEXP %>
+      <%= f.text_field :username, pattern: User::USERNAME_JS_REGEXP %>
 
       <%= f.label :bio %>
       <%= f.text_area :bio, rows: 5, placeholder: "Tell us a little about yourself! This will be visible to others.", maxlength: "250", data: {characters: ""} %>
@@ -112,4 +112,3 @@
     </div>
   <% end %>
 </div>
-

--- a/app/views/users/registrations/new.html.erb
+++ b/app/views/users/registrations/new.html.erb
@@ -12,7 +12,7 @@
       <hr class="form__divider">
 
       <%= f.label :username, class: "required" %>
-      <%= f.text_field :username,pattern: User::USERNAME_REGEXP %>
+      <%= f.text_field :username, pattern: User::USERNAME_JS_REGEXP %>
       <%= f.error :username %>
 
       <%= f.label :email, class: "required" %>


### PR DESCRIPTION
`\A` and `\Z` are not valid in JS regexp, so currently our frontend validation isn't doing anything