### PR TITLE
docs: update README to reflect actual Rails version

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # NZSL Share
 
-This is a Rails 6 app.
+This is a Rails 7 app.
 
 ## Documentation
 


### PR DESCRIPTION
(this is actually to trigger Heroku to do another deployment because the last one apparently failed due to an error on their side, but I think it was just the ubuntu-24 stack switchover being flakey)