### PR TITLE
chore: update eslint ignore patterns to exclude common generated files and directories

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -9,7 +9,17 @@ module.exports = {
     'plugin:react/recommended',
     'plugin:prettier/recommended'
   ],
-  ignorePatterns: ['tmp/'],
+  ignorePatterns: [
+    '!.eslintrc.js',
+    'node_modules/*',
+    'coverage/*',
+    'bundle/*',
+    'public/*',
+    'vendor/*',
+    'dist/*',
+    'lib/*',
+    'out/*'
+  ],
   env: {
     commonjs: true,
     node: true,


### PR DESCRIPTION
These patterns are pulled from `eslint-config-ackama`, and importantly include directories like `public/packs` which current get linted locally