### PR TITLE
refactor: remove unneeded extension on scss import

### DIFF
--- a/app/frontend/application.scss
+++ b/app/frontend/application.scss
@@ -33,6 +33,4 @@
 @import "components/sign-comments";
 @import "components/sign-examples";
 @import "components/sign-requests";
-
-// Extension is required, otherwise webpacker tries to bundle video.js.
-@import "components/video.scss";
+@import "components/video";


### PR DESCRIPTION
As far as I can tell this isn't required anymore which doesn't surprise me since we've upgraded webpack and a lot of other parts of the build pipeline - ultimately, it's getting flagged in the latest version of `stylelint` which we'll need to upgrade to address some security vulnerabilities