### PR TITLE
fix: ensure regular expressions are anchored

### DIFF
--- a/app/models/sign.rb
+++ b/app/models/sign.rb
@@ -3,7 +3,7 @@
 class Sign < ApplicationRecord
   include AASM
 
-  PERMITTED_VIDEO_CONTENT_TYPE_REGEXP = %r{\Avideo/.+|application/mp4\Z}
+  PERMITTED_VIDEO_CONTENT_TYPE_REGEXP = %r{\A(?:video/.+|application/mp4)\Z}
   PERMITTED_IMAGE_CONTENT_TYPE_REGEXP = %r{\Aimage/.+\Z}
   REFERRED_TOPIC = %r{\A/topics/\d+\Z}
   MAXIMUM_FILE_SIZE = 250.megabytes

--- a/config/application.rb
+++ b/config/application.rb
@@ -49,7 +49,7 @@ module NzslShare
 
     config.dictionary_host = ENV.fetch("NZSL_DICTIONARY_HOST", "https://nzsl.nz")
 
-    config.upload_mode = if ENV.fetch("FEATURE_MULTIPLE_UPLOAD", "true").match?(/\Atrue|y/)
+    config.upload_mode = if ENV.fetch("FEATURE_MULTIPLE_UPLOAD", "true").match?(/\A(?:true|y)\Z/)
                            :uppy
                          else
                            :legacy


### PR DESCRIPTION
These are not actually exploitable security vulnerabilities but they're being flagged by CodeQL and are subtle gotchas so we might as well address them