### PR TITLE
chore: update `sidekiq-batch` to latest RubyGem version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,7 @@ gem "redis"
 gem "sassc-rails"
 gem "shakapacker", "~> 7.0"
 gem "sidekiq"
-gem "sidekiq-batch", github: "breamware/sidekiq-batch" # required for sidekiq v7, as changes have not yet been released
+gem "sidekiq-batch"
 gem "sqlite3"
 gem "turbolinks"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,10 +1,3 @@
-GIT
-  remote: https://github.com/breamware/sidekiq-batch.git
-  revision: f2ef0289ea23e652797741de96506957535099ff
-  specs:
-    sidekiq-batch (0.1.9)
-      sidekiq (>= 7, < 8)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -406,6 +399,8 @@ GEM
       connection_pool (>= 2.3.0)
       rack (>= 2.2.4)
       redis-client (>= 0.14.0)
+    sidekiq-batch (0.2.0)
+      sidekiq (>= 7, < 8)
     simplecov (0.21.2)
       docile (~> 1.1)
       simplecov-html (~> 0.11)
@@ -492,7 +487,7 @@ DEPENDENCIES
   selenium-webdriver
   shakapacker (~> 7.0)
   sidekiq
-  sidekiq-batch!
+  sidekiq-batch
   simplecov
   sqlite3
   turbolinks


### PR DESCRIPTION
The new version with official support for Sidekiq v7 has been released so we no longer need to pull from the git repository