### PR TITLE
ci: install `libvips42`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,7 +122,7 @@ jobs:
       - name: Install required OS packages
         run: |
           sudo apt-get -y update
-          sudo apt-get -y install libpq-dev google-chrome-stable ffmpeg
+          sudo apt-get -y install libpq-dev google-chrome-stable ffmpeg libvips42
       - name: Install NodeJS
         uses: actions/setup-node@v3
         with:
@@ -169,7 +169,7 @@ jobs:
       - name: Install required OS packages
         run: |
           sudo apt-get -y update
-          sudo apt-get -y install libpq-dev google-chrome-stable ffmpeg
+          sudo apt-get -y install libpq-dev google-chrome-stable ffmpeg libvips42
 
       - name: Install NodeJS
         uses: actions/setup-node@v3


### PR DESCRIPTION
Not having this installed seems to be the cause of the recent consistent CI failing on the drag-and-drop tests about the sign not being found, and also addresses a bunch of constant redefinition warnings.

~While the test suite does pass with this, I would like confirmation from someone that knows the application better that we do expect to be using vips rather than mini_magick, as I can't find any reference to a preference or expectation in the codebase and I have found some GitHub issues suggesting there was a bug or two related to `image_processing` and Rails 7.0 having "default confusion".~ - I discussed with @joshmcarthur and he thinks this is fine