### PR TITLE
test: always create sign before running spec examples

### DIFF
--- a/spec/system/edit_sign_illustrations_spec.rb
+++ b/spec/system/edit_sign_illustrations_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe "Edit sign illustrations", type: :system do
   include ActionView::Helpers::NumberHelper
 
   let(:user) { FactoryBot.create(:user, :approved) }
-  let(:sign) { FactoryBot.create(:sign, :unprocessed, contributor: user) }
+  let!(:sign) { FactoryBot.create(:sign, :unprocessed, contributor: user) }
   subject { page }
 
   before do

--- a/spec/system/edit_sign_usage_examples_spec.rb
+++ b/spec/system/edit_sign_usage_examples_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe "Editing sign usage examples", type: :system do
   include ActionView::Helpers::NumberHelper
 
   let(:user) { FactoryBot.create(:user, :approved) }
-  let(:sign) { FactoryBot.create(:sign, :unprocessed, contributor: user) }
+  let!(:sign) { FactoryBot.create(:sign, :unprocessed, contributor: user) }
   subject { page }
 
   before do


### PR DESCRIPTION
Currently these system specs consistently fails about not being able to find the sign, which I suspect is due to a race condition that I can't pin down, but having the sign always be created before the examples run seems to resolve it