### PR TITLE
chore: remove patched advisories from ignore list

### DIFF
--- a/.osv-detector.yml
+++ b/.osv-detector.yml
@@ -1,7 +1,2 @@
 ignore:
-  - GHSA-3h5v-q93c-6h6q
-  - GHSA-7fh5-64p2-3v2j
-  - GHSA-grv7-fg5c-xmjg
   - GHSA-vh95-rmgr-6w4m
-  - GHSA-w5p7-h5w8-2hfq
-  - GHSA-xvch-5gv4-984h


### PR DESCRIPTION
These have been patched via #684