### PR TITLE
fix: don't verify redis SSL certificate for sidekiq

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,0 +1,8 @@
+# https://devcenter.heroku.com/articles/connecting-heroku-redis#connecting-from-sidekiq
+Sidekiq.configure_server do |config|
+  config.redis = { ssl_params: { verify_mode: OpenSSL::SSL::VERIFY_NONE } }
+end
+
+Sidekiq.configure_client do |config|
+  config.redis = { ssl_params: { verify_mode: OpenSSL::SSL::VERIFY_NONE } }
+end


### PR DESCRIPTION
Heroku Redis uses a self-signed certificate meaning we shouldn't try and validate the certificate.

Also see https://help.heroku.com/HC0F8CUS/redis-connection-issues