### PR TITLE
fix: add a few more ffmpeg arguments to ensure compatibility with QuickTime/HEVC

### DIFF
--- a/app/models/video_encoding_preset.rb
+++ b/app/models/video_encoding_preset.rb
@@ -20,7 +20,7 @@ class VideoEncodingPreset
 
   def initialize(overrides = [])
     # These base presets are from https://gist.github.com/Vestride/278e13915894821e1d6f#convert-to-mp4
-    @presets = Set.new(["-vcodec", "libx264", "-pix_fmt", "yuv420p", "-profile:v", "baseline", "-level", "3"]).merge(overrides)
+    @presets = Set.new(%w[-vcodec libx264 -pix_fmt yuv420p -profile:v baseline -level 3]).merge(overrides)
   end
 
   delegate :to_a, to: :@presets

--- a/app/models/video_encoding_preset.rb
+++ b/app/models/video_encoding_preset.rb
@@ -20,7 +20,7 @@ class VideoEncodingPreset
 
   def initialize(overrides = [])
     # These base presets are from https://gist.github.com/Vestride/278e13915894821e1d6f#convert-to-mp4
-    @presets = Set.new(["-profile:v", "baseline", "-level", "3"]).merge(overrides)
+    @presets = Set.new(["-vcodec", "libx264", "-pix_fmt", "yuv420p", "-profile:v", "baseline", "-level", "3"]).merge(overrides)
   end
 
   delegate :to_a, to: :@presets


### PR DESCRIPTION
We've had a few failures in processing video files which have come from QuickTime, and it turns out to be that there's a colorspace difference that we need to account for; from our research, it doesn't seem that there's a significant downside to doing this regardless of where the video actually came from 🤷 