### PR TITLE
CC-2445: use heroku-cli for deployments 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,3 +196,39 @@ jobs:
           name: rspec-output-screenshots
           path: tmp/capybara
           retention-days: 5
+
+  # ######################################################################### #
+  # Deploy to Heroku
+  # ######################################################################### #
+
+  deploy_to_heroku_staging:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs:
+      - check-dependencies
+      - format
+      - rspec
+    uses: ./.github/workflows/deploy_to_heroku.yml
+    with:
+      environment: staging
+      environment_url: https://nzsl-share-uat.herokuapp.com/
+    secrets:
+      heroku_api_key: ${{ secrets.HEROKU_API_KEY }}
+      heroku_email: ${{ secrets.HEROKU_EMAIL }}
+      heroku_app_name: ${{ secrets.HEROKU_APP_NAME_STAGING }}
+      slack_webhook: ${{ secrets.SLACK_WEBHOOK }}
+
+  deploy_to_heroku_production:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/production'
+    needs:
+      - check-dependencies
+      - format
+      - rspec
+    uses: ./.github/workflows/deploy_to_heroku.yml
+    with:
+      environment: production
+      environment_url: https://www.nzslshare.nz/
+    secrets:
+      heroku_api_key: ${{ secrets.HEROKU_API_KEY }}
+      heroku_email: ${{ secrets.HEROKU_EMAIL }}
+      heroku_app_name: ${{ secrets.HEROKU_APP_NAME_PRODUCTION }}
+      slack_webhook: ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -210,7 +210,7 @@ jobs:
     uses: ./.github/workflows/deploy_to_heroku.yml
     with:
       environment: staging
-      environment_url: https://nzsl-share-uat.herokuapp.com/
+      environment_url: https://uat.nzslshare.nz
     secrets:
       heroku_api_key: ${{ secrets.HEROKU_API_KEY }}
       heroku_email: ${{ secrets.HEROKU_EMAIL }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -201,7 +201,7 @@ jobs:
   # Deploy to Heroku
   # ######################################################################### #
 
-  deploy_to_heroku_staging:
+  deploy_to_heroku_uat:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     needs:
       - check-dependencies
@@ -209,7 +209,7 @@ jobs:
       - rspec
     uses: ./.github/workflows/deploy_to_heroku.yml
     with:
-      environment: staging
+      environment: uat
       environment_url: https://uat.nzslshare.nz
     secrets:
       heroku_api_key: ${{ secrets.HEROKU_API_KEY }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -226,7 +226,7 @@ jobs:
     uses: ./.github/workflows/deploy_to_heroku.yml
     with:
       environment: production
-      environment_url: https://www.nzslshare.nz/
+      environment_url: https://www.nzslshare.nz
     secrets:
       heroku_api_key: ${{ secrets.HEROKU_API_KEY }}
       heroku_email: ${{ secrets.HEROKU_EMAIL }}

--- a/.github/workflows/deploy_to_heroku.yml
+++ b/.github/workflows/deploy_to_heroku.yml
@@ -1,0 +1,71 @@
+name: deploy_to_heroku
+on:
+  workflow_call:
+    inputs:
+      environment:
+        type: string
+        required: true
+      environment_url:
+        type: string
+        required: false
+      timeout_minutes:
+        type: number
+        required: false
+        default: 15
+      slack_icon:
+        type: string
+        required: false
+        default: https://github.com/ackama.png?size=48
+      slack_channel:
+        type: string
+        required: false
+      slack_username:
+        type: string
+        required: false
+        default: 'Github Actions CI'
+    secrets:
+      heroku_api_key:
+        required: true
+      heroku_app_name:
+        required: true
+      heroku_email:
+        required: true
+      slack_webhook:
+        required: false
+
+# These are the permissions required by this nested workflow to function.
+#
+# You should include a copy of this block next to any `uses:` of this workflow
+permissions:
+  contents: read # to fetch code (actions/checkout)
+
+jobs:
+  deploy_to_heroku:
+    runs-on: ubuntu-latest
+    timeout-minutes: ${{ inputs.timeout_minutes }}
+    environment:
+      name: ${{ inputs.environment }}
+      url: ${{ inputs.environment_url }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: true # required to push to heroku
+      - run: curl https://cli-assets.heroku.com/install-ubuntu.sh | sh
+      - name: Deploy to Heroku
+        uses: akhileshns/heroku-deploy@v3.12.14
+        with:
+          heroku_api_key: ${{ secrets.heroku_api_key }}
+          heroku_email: ${{ secrets.heroku_email }}
+          heroku_app_name: ${{ secrets.heroku_app_name }}
+      - name: Report to Slack
+        if: "${{ inputs.slack_channel != '' }}"
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_WEBHOOK: ${{ secrets.slack_webhook }}
+          SLACK_CHANNEL: ${{ inputs.slack_channel }}
+          SLACK_ICON: ${{ inputs.slack_icon }}
+          SLACK_USERNAME: ${{ inputs.slack_username }}
+          SLACK_FOOTER: ''
+          SLACK_COLOR: ${{ job.status }}
+          SLACK_MESSAGE:
+            "${{ format('{0} job result: {1}', github.job, job.status) }}"


### PR DESCRIPTION
This PR switches us to using the Heroku CLI for deployments to be consistent with our other codebases and so that deployments can be automatically tracked in Mahi