### PR TITLE
fix: update net-imap for security

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -240,7 +240,7 @@ GEM
     msgpack (1.4.2)
     multi_xml (0.6.0)
     multipart-post (2.1.1)
-    net-imap (0.5.6)
+    net-imap (0.5.7)
       date
       net-protocol
     net-pop (0.1.2)


### PR DESCRIPTION

  net-imap@0.5.6 is affected by the following vulnerabilities:
    GHSA-j3g3-5qv5-52mj: net-imap rubygem vulnerable to possible DoS by memory exhaustion (https://github.com/advisories/GHSA-j3g3-5qv5-52mj)

