### PR TITLE
CC-2379 Replace secrets with app, as secrets were deprecated in rails 7.1

### DIFF
--- a/config/app.yml
+++ b/config/app.yml
@@ -1,8 +1,8 @@
 # Be sure to restart your server when you modify this file.
-# Make sure the secrets in this file are kept private
-# if you're sharing your code publicly.
+#
+# Use this file to load configuration values from the environment, which will
+# be accessible by the app through `Rails.application.config.app`
 
-# Environmental secrets are only available for that specific environment.
 default: &default
   # Your secret key is used for verifying the integrity of signed cookies.
   # If you change this key, all old signed cookies will become invalid!

--- a/config/application.rb
+++ b/config/application.rb
@@ -12,6 +12,11 @@ module NzslShare
     config.load_defaults 7.2
     config.time_zone = "Wellington"
 
+    # load config/app.yml into Rails.application.config.app.*
+    config.app = config_for(:app)
+    # pull the secret_key_base from our app config
+    config.secret_key_base = config.app.secret_key_base
+
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -80,11 +80,11 @@ Rails.application.configure do
   config.action_mailer.raise_delivery_errors = true
   config.action_mailer.default_url_options[:protocol] = "https"
   config.action_mailer.smtp_settings = {
-    address: Rails.application.secrets.smtp_hostname,
+    address: Rails.application.config.app.smtp_hostname,
     port: 587,
     enable_starttls_auto: true,
-    user_name: Rails.application.secrets.smtp_user_name,
-    password: Rails.application.secrets.smtp_password,
+    user_name: Rails.application.config.app.smtp_user_name,
+    password: Rails.application.config.app.smtp_password,
     authentication: "login",
     domain: ENV.fetch("HOSTNAME", nil)
   }


### PR DESCRIPTION
I forgot to replace secrets with app when I upgraded to rails 7.2, and secrets was deprecated in 7.1, and the deployment to testing is failing because its trying to read vars from secrets which no longer exist