### PR TITLE
fix: make "import from video recording" text a bit bigger

### DIFF
--- a/app/frontend/components/uppy-file-upload.scss
+++ b/app/frontend/components/uppy-file-upload.scss
@@ -13,6 +13,13 @@ $gray-600: $neutral-gray;
   float: left; // Fix invalid inline-start float property from Uppy
 }
 
+// Make things a bit bigger on mobie
+.uppy-DashboardContent-back,
+.uppy-DashboardContent-title {
+  font-size: 14px;
+  min-width: min-content;
+}
+
 // Make bold text antialiased
 .uppy-Root {
   -webkit-font-smoothing: antialiased;


### PR DESCRIPTION
This makes things a bit easier to read on mobile without (hopefully) impacting the rest of the structure

Before:

<img width="528" height="978" alt="image" src="https://github.com/user-attachments/assets/b38bdaa0-ceff-4cf9-a3f3-0a1d25e779a1" />

After:

<img width="538" height="970" alt="image" src="https://github.com/user-attachments/assets/4f74042a-56c3-4f87-a2dd-aa6ca9782b3c" />
