### PR TITLE
chore: ignore GHSA-w5hq-g745-h8pq

### DIFF
--- a/.osv-detector.yml
+++ b/.osv-detector.yml
@@ -1,2 +1,2 @@
 ignore:
-  - GHSA-gmq8-994r-jv83
+  - GHSA-w5hq-g745-h8pq


### PR DESCRIPTION
We're not vulnerable since GHSA-w5hq-g745-h8pq does not impact the UUID v4 generator which is what it's being used for by our dependencies