### PR TITLE
CCSD-5859 link_to no longer posts only gets

### DIFF
--- a/app/views/admin/approved_user_applications/show.html.erb
+++ b/app/views/admin/approved_user_applications/show.html.erb
@@ -37,15 +37,14 @@ as well as a link to its edit page.
         <div class="form__footer">
           <%= link_to "Decline",
                       [:decline, :admin, page.resource],
-                      method: :post,
+                      data: { turbo_method: :post },
                       class: "button alert margin-right-1" if policy(page.resource).decline? %>
 
           <%= link_to "Accept",
                       [:accept, :admin, page.resource],
-                      method: :post,
+                      data: { turbo_method: :post },
                       class: "button" if policy(page.resource).accept? %>
         </div>
     <% end %>
   </div>
 </div>
-


### PR DESCRIPTION
link_to no longer posts only gets

this was causing a 404 in the approved_user_applications UI as it was asking for a route that doesn't exist:

```
2026-05-20T01:29:53.914175+00:00 heroku[router]: at=info method=GET path="/admin/approved_user_applications/358/accept" host=www.nzslshare.nz request_id=af7691ff-c095-2488-3d68-2f1cf3af33ca fwd="2407:7000:ae68:600:90e2:1d88:97a1:6601, 104.23.198.143" dyno=web.1 connect=0ms service=6ms status=404 bytes=11082 protocol=http2.0 tls=true tls_version=tls1.3
2026-05-20T01:29:53.909846+00:00 app[web.1]: I, [2026-05-20T01:29:53.909789 #2]  INFO -- : [af7691ff-c095-2488-3d68-2f1cf3af33ca] Started GET "/admin/approved_user_applications/358/accept" for 104.23.198.143 at 2026-05-20 01:29:53 +0000
2026-05-20T01:29:53.913495+00:00 app[web.1]: E, [2026-05-20T01:29:53.912745 #2] ERROR -- : [af7691ff-c095-2488-3d68-2f1cf3af33ca]
2026-05-20T01:29:53.913497+00:00 app[web.1]: [af7691ff-c095-2488-3d68-2f1cf3af33ca] ActionController::RoutingError (No route matches [GET] "/admin/approved_user_applications/358/accept"):
```

since we are using turbo we can use the turbo_method to do a post and this seems to work.

I tested the other 2 link_tos that use that method post and they seem to work so I dunno whats happening there