### PR TITLE
CC-2613: setup workflow to enforce "conventional titles"

### DIFF
--- a/.github/workflows/title.yml
+++ b/.github/workflows/title.yml
@@ -1,0 +1,41 @@
+name: PR Title
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - reopened
+      - synchronize
+concurrency:
+  # Pushing new changes to a branch will cancel any in-progress CI runs
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+# Restrict jobs in this workflow to have no permissions by default; permissions
+# should be granted per job as needed using a dedicated `permissions` block
+permissions: {}
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    if: github.head_ref != 'main' || github.base_ref != 'production'
+    permissions:
+      pull-requests: read
+    steps:
+      - uses: amannn/action-semantic-pull-request@v6.1.0
+        with:
+          types: |
+            build
+            chore
+            ci
+            docs
+            feat
+            fix
+            perf
+            refactor
+            revert
+            test
+            [A-Z][A-Z\d]+-\d+
+          headerPattern: '^([\w-]*)(?:\(([\w$.\-*/ ]*)\))?: (.*)$'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Since we squash when merging PRs and use the PR title as the commit message, this workflow helps ensure our [commit
conventions](https://www.notion.so/ackamagroup/Git-and-PR-Conventions-311795777d2280429c22d028c1bb95a2?source=copy_link) are followed by requiring PR titles to start with either a JIRA ticket key or one of the defined types followed, followed by a colon