### PR TITLE
CCSD-5856: update effective date and video link

### DIFF
--- a/app/views/static/copyright.html.erb
+++ b/app/views/static/copyright.html.erb
@@ -5,7 +5,10 @@
 <h1>VUW NZSL RESOURCES LICENCE</h1>
 
 
-<p><strong>Effective date:</strong> 2026</p>
+<p><strong>Effective date:</strong> 1 June 2026</p>
+
+<iframe src="https://player.vimeo.com/video/1196510073" width="640" height="360" frameborder="0" allow="autoplay; fullscreen" allowfullscreen></iframe>
+
 
 <ul>
   <li><a href="#about-these-terms">About these terms</a></li>


### PR DESCRIPTION
This updates the effective date for the copyright to the date provided by Micky. 

The video doesn't work in localhost- but I'd like to test that on staging because as an unlisted video it does work when I hit the link for the video. 

<img width="2372" height="1206" alt="CleanShot 2026-06-02 at 17 19 18@2x" src="https://github.com/user-attachments/assets/eb5cf9d5-dca4-4bcf-9fe3-43d343bfff03" />
