### PR TITLE
fix: update `concurrent-ruby` for security

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -135,7 +135,7 @@ GEM
     coderay (1.1.3)
     coercible (1.0.0)
       descendants_tracker (~> 0.0.1)
-    concurrent-ruby (1.3.6)
+    concurrent-ruby (1.3.7)
     connection_pool (3.0.2)
     crass (1.0.6)
     csv (3.3.5)


### PR DESCRIPTION
Addresses GHSA-6wx8-w4f5-wwcr
Addresses GHSA-h8w8-99g7-qmvj
Addresses GHSA-wv3x-4vxv-whpp