### PR TITLE
chore: ignore `faraday` and `concurrent-ruby` advisories

### DIFF
--- a/.osv-detector.yml
+++ b/.osv-detector.yml
@@ -1,2 +1,6 @@
 ignore:
+  - GHSA-98m9-hrrm-r99r
+  - GHSA-6wx8-w4f5-wwcr
+  - GHSA-h8w8-99g7-qmvj
+  - GHSA-wv3x-4vxv-whpp
   - GHSA-w5hq-g745-h8pq


### PR DESCRIPTION
* `concurrent-ruby` looks to have a glitch (#894)
* `faraday` requires a major version upgrade which I would expect is straightforward, but I want to get everything else we can out first